### PR TITLE
Update 03_assignment.zig | Missing Line In Example

### DIFF
--- a/exercises/03_assignment.zig
+++ b/exercises/03_assignment.zig
@@ -21,7 +21,7 @@
 //          bar can hold 16 bits (0 to 65,535)
 //
 //     const foo: u8 = 20;
-//     var bar: u16 = 2000;
+//     const bar: u16 = 2000;
 //
 // You can do just about any combination of these that you can think of:
 // 

--- a/exercises/03_assignment.zig
+++ b/exercises/03_assignment.zig
@@ -20,6 +20,9 @@
 // Example: foo can hold 8 bits (0 to 255)
 //          bar can hold 16 bits (0 to 65,535)
 //
+//     const foo: u8 = 20;
+//     var bar: u16 = 2000;
+//
 // You can do just about any combination of these that you can think of:
 // 
 //     u32 can hold 0 to 4,294,967,295


### PR DESCRIPTION
Looks like one of the example lines was missing.

set `bar` to a value that wouldn't have fit in `foo` _(like the other examples seem to be doing)_