### PR TITLE
04_arrays.zig - missing ":" for type of example array

### DIFF
--- a/exercises/04_arrays.zig
+++ b/exercises/04_arrays.zig
@@ -1,7 +1,7 @@
 //
 // Let's learn some array basics. Arrays are declared with:
 //
-//   var foo [3]u32 = [3]u32{ 42, 108, 5423 };
+//   var foo: [3]u32 = [3]u32{ 42, 108, 5423 };
 //
 // When Zig can infer the size of the array, you can use '_' for the
 // size. You can also let Zig infer the type of the value so the


### PR DESCRIPTION
Small fix, the first example declares the array with a type but does not include the colon which I believe is invalid syntax.