### PR TITLE
Exercise 12 fixes

### DIFF
--- a/exercises/12_while2.zig
+++ b/exercises/12_while2.zig
@@ -4,14 +4,14 @@
 // end of the loop or when an explicit 'continue' is invoked (we'll
 // try those out next):
 //
-//     while (condition) : (continue expression)
+//     while (condition) : (continue expression) {
 //         ...
 //     }
 //
 // Example:
 //
 //     var foo = 2;
-//     while (foo<10) : (foo+=2)
+//     while (foo<10) : (foo+=2) {
 //         // Do something with even numbers less than 10...
 //     }
 //

--- a/exercises/12_while2.zig
+++ b/exercises/12_while2.zig
@@ -1,7 +1,7 @@
 //
 // Zig 'while' statements can have an optional 'continue expression'
 // which runs every time the while loop continues (either at the
-// end of the loop or when an explicit 'continue' is invoked (we'll
+// end of the loop or when an explicit 'continue' is invoked - we'll
 // try those out next):
 //
 //     while (condition) : (continue expression) {


### PR DESCRIPTION
Minor textual corrections to exercise 12 documentation:

- Add missing opening brace in while statements
- Replace unmatched opening parenthetical with a dash