### PR TITLE
Test nightly against zig unstable

### DIFF
--- a/.github/workflows/eowyn.yml
+++ b/.github/workflows/eowyn.yml
@@ -1,0 +1,25 @@
+name: Eowyn
+on:
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: "0 0 * * *"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Zig
+      uses: goto-bus-stop/setup-zig@v1.3.0
+      with:
+        version: master
+
+    - run: patches/eowyn.sh

--- a/patches/eowyn.sh
+++ b/patches/eowyn.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #     "I will be a shieldmaiden no longer,
 #      nor vie with the great Riders, nor
@@ -12,8 +12,6 @@
 # using the patches in this directory and convey them
 # to convalesce in the healed directory.
 #
-
-set -e
 
 # We run from the patches dir. Go there now if not already.
 cd $(dirname $(realpath $0))

--- a/patches/eowyn.sh
+++ b/patches/eowyn.sh
@@ -14,7 +14,7 @@
 #
 
 # We run from the patches dir. Go there now if not already.
-cd $(dirname $(realpath $0))
+cd $(dirname $0)
 pwd # Show it upon the screen so all shall be made apparent.
 
 # Create healed/ directory here if it doesn't already exist.

--- a/patches/eowyn.sh
+++ b/patches/eowyn.sh
@@ -13,6 +13,8 @@
 # to convalesce in the healed directory.
 #
 
+set -e
+
 # We run from the patches dir. Go there now if not already.
 cd $(dirname $(realpath $0))
 pwd # Show it upon the screen so all shall be made apparent.


### PR DESCRIPTION
had to make a couple minor changes to the bash scripts such as setting the shebang to bash since `[[` is used, and macos didn't have `realpath` for some reason, but it seems to work fine without