### PR TITLE
Use double quotes for Zig strings

### DIFF
--- a/exercises/22_errors2.zig
+++ b/exercises/22_errors2.zig
@@ -2,15 +2,15 @@
 // A common case for errors is a situation where we're expecting to
 // have a value OR something has gone wrong. Take this example:
 //
-//     var text: Text = getText('foo.txt');
+//     var text: Text = getText("foo.txt");
 //
-// What happens if getText() can't find 'foo.txt'?  How do we express
+// What happens if getText() can't find "foo.txt"?  How do we express
 // this in Zig?
 //
 // Zig lets us make what's called an "error union" which is a value
 // which could either be a regular value OR an error from a set:
 //
-//     var text: MyErrorSet!Text = getText('foo.txt');
+//     var text: MyErrorSet!Text = getText("foo.txt");
 //
 // For now, let's just see if we can try making an error union!
 //


### PR DESCRIPTION
Just changing the strings in the example code to use double quotes for the stings instead of single quotes.