### PR TITLE
Cleaned up some trailing whitespace

### DIFF
--- a/exercises/017_quiz2.zig
+++ b/exercises/017_quiz2.zig
@@ -3,7 +3,7 @@
 //
 //     "Players take turns to count incrementally, replacing
 //      any number divisible by three with the word "fizz",
-//      and any number divisible by five with the word "buzz". 
+//      and any number divisible by five with the word "buzz".
 //          - From https://en.wikipedia.org/wiki/Fizz_buzz
 //
 // Let's go from 1 to 16.  This has been started for you, but there's

--- a/exercises/024_errors4.zig
+++ b/exercises/024_errors4.zig
@@ -59,7 +59,7 @@ fn fixTooSmall(n: u32) MyNumberError!u32 {
     // If we get a TooSmall error, we should return 10.
     // If we get any other error, we should return that error.
     // Otherwise, we return the u32 number.
-    return detectProblems(n) ??? 
+    return detectProblems(n) ???
 }
 
 fn detectProblems(n: u32) MyNumberError!u32 {

--- a/exercises/053_slices2.zig
+++ b/exercises/053_slices2.zig
@@ -8,7 +8,7 @@
 //     var foo: []u8 = "foobar"[0..3];
 //
 // to:
-//   
+//
 //     var foo: []const u8 = "foobar"[0..3];
 //
 // See if you can fix this Zero Wing-inspired phrase descrambler:


### PR DESCRIPTION
Just stripped out a few more trailing whitespace characters.  I'm not really specifically looking for these, but I have my editor (VS Code) set to strip trailing whitespace on save, so if there are accidental spaces at the end of a line, they are automatically removed and show up in the diff.