### PR TITLE
008_quiz: Replaced the type of the index variable

### DIFF
--- a/exercises/008_quiz.zig
+++ b/exercises/008_quiz.zig
@@ -13,7 +13,7 @@ pub fn main() void {
     // What is this nonsense? :-)
     const letters = "YZhifg";
 
-    const x: u8 = 1;
+    const x: usize = 1;
 
     // This is something you haven't seen before: declaring an array
     // without putting anything in it. There is no error here:


### PR DESCRIPTION
Replaced the type of the `x` variable to `usize` instead of `u8`.
I may be wrong, but `usize` is more preferable when indexing or declaring an array.