### PR TITLE
fix typo in 067_comptime2.zig

### DIFF
--- a/exercises/067_comptime2.zig
+++ b/exercises/067_comptime2.zig
@@ -24,8 +24,8 @@
 // to use a comptime_int of undetermined size at runtime is
 // a MEMORY CRIME and you are UNDER ARREST.
 //
-// The second one is is okay because we've told Zig that 'bar2'
-// is a compile time variable. Zig will help us ensure this is true
+// The second one is okay because we've told Zig that 'bar2' is
+// a compile time variable. Zig will help us ensure this is true
 // and let us know if we make a mistake.
 //
 const print = @import("std").debug.print;


### PR DESCRIPTION
This removes duplicated "is".
I've also moved "is" from line 28 up to balance line widths. 

PS: Thank you for making Ziglings!