### PR TITLE
Initial support for zig 0.8.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ const print = std.debug.print;
 // When changing this version, be sure to also update README.md in two places:
 //     1) Getting Started
 //     2) Version Changes
-const needed_version = std.SemanticVersion.parse("0.9.0-dev.1343") catch unreachable;
+const needed_version = std.SemanticVersion.parse("0.8.1") catch unreachable;
 
 const Exercise = struct {
     /// main_file must have the format key_name.zig.
@@ -565,7 +565,7 @@ pub fn build(b: *Builder) void {
         named_verify.dependOn(&verify_step.step);
 
         const chain_verify = b.allocator.create(Step) catch unreachable;
-        chain_verify.* = Step.initNoOp(.custom, b.fmt("chain {s}", .{key}), b.allocator);
+        chain_verify.* = Step.initNoOp(.Custom, b.fmt("chain {s}", .{key}), b.allocator);
         chain_verify.dependOn(&verify_step.step);
 
         const named_chain = b.step(b.fmt("{s}_start", .{key}), b.fmt("Check all solutions starting at {s}", .{ex.main_file}));
@@ -592,7 +592,7 @@ const ZiglingStep = struct {
     pub fn create(builder: *Builder, exercise: Exercise, use_healed: bool) *@This() {
         const self = builder.allocator.create(@This()) catch unreachable;
         self.* = .{
-            .step = Step.init(.custom, exercise.main_file, builder.allocator, make),
+            .step = Step.init(.Custom, exercise.main_file, builder.allocator, make),
             .exercise = exercise,
             .builder = builder,
             .use_healed = use_healed,


### PR DESCRIPTION
Add initial support for zig 0.8.1. Other fixes might be needed in some
exercises, but this patch is sufficient for the first ones. 

I tested all the way up to exercise 34 for now.

If I need to push other fixes after this PR has been merged, I will do it in other PRs.