### PR TITLE
Fix build on latest nightly zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -624,8 +624,7 @@ const ZiglingStep = struct {
 
         const argv = [_][]const u8{exe_file};
 
-        const child = std.ChildProcess.init(&argv, self.builder.allocator) catch unreachable;
-        defer child.deinit();
+        var child = std.ChildProcess.init(&argv, self.builder.allocator);
 
         child.cwd = cwd;
         child.env_map = self.builder.env_map;


### PR DESCRIPTION
I'm not sure what the implications of not `deinit`ing the child process are, but it seems that `ChildProcess` no longer has a `.deinit()` method in the new nightly. #98 