### PR TITLE
handle changes to ChildProcess.init api

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -624,8 +624,7 @@ const ZiglingStep = struct {
 
         const argv = [_][]const u8{exe_file};
 
-        const child = std.ChildProcess.init(&argv, self.builder.allocator) catch unreachable;
-        defer child.deinit();
+        var child = std.ChildProcess.init(&argv, self.builder.allocator);
 
         child.cwd = cwd;
         child.env_map = self.builder.env_map;


### PR DESCRIPTION
following https://github.com/ziglang/zig/commit/a0a2ce92ca129d28e22c63f7bace1672c43776b5
- ChildProcess.init no longer returns an error union
- calls to `init` no longer require call to `deinit`

PR built with `zig version == 0.10.0-dev.2083+13d1798ea` 