### PR TITLE
064_builtins: clarify @addWithOverflow explanation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -331,7 +331,7 @@ const exercises = [_]Exercise{
     },
     .{
         .main_file = "064_builtins.zig",
-        .output = "1101 + 0101 = 0010 (true). Furthermore, 11110000 backwards is 00001111.",
+        .output = "1101 + 0101 = 0010 (true). Without overflow: 00010010. Furthermore, 11110000 backwards is 00001111.",
     },
     .{
         .main_file = "065_builtins2.zig",

--- a/exercises/064_builtins.zig
+++ b/exercises/064_builtins.zig
@@ -41,22 +41,38 @@ pub fn main() void {
     var my_result: u4 = undefined;
     var overflowed: bool = undefined;
     overflowed = @addWithOverflow(u4, a, b, &my_result);
-    //
-    // The print() below will produce: "1101 + 0101 = 0010 (true)".
-    // Let's make sense of this answer by counting up from 1101:
-    //
-    //                     Overflowed?
-    //    1101 + 1 = 1110      No.
-    //    1110 + 1 = 1111      No.
-    //    1111 + 1 = 0000      Yes! (Real answer is 10000)
-    //    0000 + 1 = 0001      No.
-    //    0001 + 1 = 0010      No.
-    //
-    // Also, check out our fancy formatting! b:0>4 means, "print
+
+    // Check out our fancy formatting! b:0>4 means, "print
     // as a binary number, zero-pad right-aligned four digits."
+    // The print() below will produce: "1101 + 0101 = 0010 (true)".
     print("{b:0>4} + {b:0>4} = {b:0>4} ({})", .{ a, b, my_result, overflowed });
 
-    print(". Furthermore, ", .{});
+    // Let's make sense of this answer. The value of 'b' in decimal is 5.
+    // Let's add 5 to 'a' but go one by one and see where it overflows:
+    //
+    //   a  |  b   | result | overflowed?
+    // ----------------------------------
+    // 1101 + 0001 =  1110  | false
+    // 1110 + 0001 =  1111  | false
+    // 1111 + 0001 =  0000  | true  (the real answer is 10000)
+    // 0000 + 0001 =  0001  | false
+    // 0001 + 0001 =  0010  | false
+    //
+    // In the last two lines the value of 'a' is corrupted because there was
+    // an overflow in line 3, but the operations of lines 4 and 5 themselves
+    // do not overflow.
+    // There is a difference between
+    //  - a value, that overflowed at some point and is now corrupted
+    //  - a single operation that overflows and maybe causes subsequent errors
+    // In practise we usually notice the overflowed value first and have to work
+    // our way backwards to the operation that caused the overflow.
+    //
+    // If there was no overflow at all while adding 5 to a, what value would
+    // 'my_result' hold? Write the answer in into 'expected_result'.
+    const expected_result: u8 = ???;
+    print(". Without overflow: {b:0>8}. ", .{expected_result});
+
+    print("Furthermore, ", .{});
 
     // Here's a fun one:
     //

--- a/patches/patches/064_builtins.patch
+++ b/patches/patches/064_builtins.patch
@@ -1,4 +1,6 @@
 72c72
-<     const tupni: u8 = @bitReverse(input);
----
->     const tupni: u8 = @bitReverse(u8, input);
+-    const expected_result: u8 = ???;
++    const expected_result: u8 = 0b00010010;
+88c88
+-     const tupni: u8 = @bitReverse(input);
++     const tupni: u8 = @bitReverse(u8, input);


### PR DESCRIPTION
There were misunderstandings concerning overflowing operations and overflowed variables, see #94 for the discussion.
This PR is a draft for an explanation that is hopefully clearer.

I tried to keep the explanation relatively short, because I'm hoping that the direct relation to the code and variables is sufficient. That could be a mistake and probably needs feedback from users.

Also the user has one additional question to correct to make sure they understood the builtin (with the drawback of frustrating them if the explanation is still not clear enough -> meh). The main reason I added the question, was that reading a big chunk of text about overflow and not being asked a verifying question felt like a small let down.

