### PR TITLE
Replace "−" with "-" in Assigment 3 tutorial text

### DIFF
--- a/exercises/003_assignment.zig
+++ b/exercises/003_assignment.zig
@@ -12,7 +12,7 @@
 //     var bar: u8 = 20;
 //
 // Example: foo cannot be negative and can hold 0 to 255
-//          bar CAN be negative and can hold −128 to 127
+//          bar CAN be negative and can hold -128 to 127
 //
 //     const foo: u8 = 20;
 //     const bar: i8 = -20;
@@ -26,7 +26,7 @@
 // You can do just about any combination of these that you can think of:
 //
 //     u32 can hold 0 to 4,294,967,295
-//     i64 can hold −9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+//     i64 can hold -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
 //
 // Please fix this program so that the types can hold the desired values
 // and the errors go away!


### PR DESCRIPTION
When viewing this file in VSCode, I saw the following warning highlighting lines `15` and `29`

```
The character U+2212 "−" could be confused with the character U+002d "-", which is more common in source code.
```
![confused-character](https://user-images.githubusercontent.com/5403345/172028601-c5a15bab-48e4-437c-a4fc-38b64cedc06f.png)


It seems to me this is just a small oversight, as "-" is used elsewhere in the commented block to denote a negative value, but I'll freely admit ignorance as to any nuance here in using one vs. the other.