### PR TITLE
007_strings2.zig - highlight to student that they must not use comments for multi line

### DIFF
--- a/exercises/007_strings2.zig
+++ b/exercises/007_strings2.zig
@@ -9,6 +9,9 @@
 //         \\Line Two
 //     ;
 //
+// If you get the error: "expected expression, found ';'" 
+// that means you used forward slashes, multi line strings are not comments 
+//
 // See if you can make this program print some song lyrics.
 //
 const std = @import("std");


### PR DESCRIPTION
As a developer who writes allot of // my brain didn't compute the idea of it being around the other way. I spent a good 10 min on this until I slowed down and actually read. Potentially not a PR worth merging but maybe?