### PR TITLE
Fix issue with formatting from std library updates

### DIFF
--- a/exercises/050_no_value.zig
+++ b/exercises/050_no_value.zig
@@ -71,7 +71,7 @@ pub fn main() void {
     var first_line2: Err!*const [21]u8 = ???;
     first_line2 = "which can eternal lie";
 
-    std.debug.print("{s} {s} / ", .{ first_line1, first_line2 });
+    std.debug.print("{s} {!s} / ", .{ first_line1, first_line2 });
 
     printSecondLine();
 }

--- a/exercises/082_anonymous_structs3.zig
+++ b/exercises/082_anonymous_structs3.zig
@@ -116,7 +116,7 @@ fn printTuple(tuple: anytype) void {
         //         @field(foo, "x"); // returns the value at foo.x
         //
         // The first field should print as: "0"(bool):true
-        print("\"{s}\"({s}):{any} ", .{
+        print("\"{s}\"({any}):{any} ", .{
             field.???,
             field.???,
             ???,


### PR DESCRIPTION
Recent changes to the requirements for format specifiers broke a couple of exercises unexpectedly

- 050 failed to print the error union, since the new expected format specifier is `{!s}` for string error unions.
- 082 failed to print the type, as apparently declaring bespoke types as `{s}` is no longer supported and thus must be declared as `{any}` (at least, that's the only way I could get it to be happy)

Tested with `zig` version `zig-macos-aarch64-0.10.0-dev.3362+e863292fe`

Error output from previously working solution for 050:
Previously Working Solution: [050_no_value.zig.txt](https://github.com/ratfactor/ziglings/files/9215012/050_no_value.zig.txt) (Apparently `.zig` is rejected by GitHub :/ )
```shell
> zig build 50
Compiling 050_no_value.zig...
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:508:17: error: cannot format error union without a specifier (i.e. {!} or {any})
                @compileError("cannot format error union without a specifier (i.e. {!} or {any})");
                ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:183:23: note: called from here
        try formatType(
                      ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/io/writer.zig:28:34: note: called from here
            return std.fmt.format(self, format, args);
                                 ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/debug.zig:93:27: note: called from here
    nosuspend stderr.print(fmt, args) catch return;
                          ^
./exercises/050_no_value.zig:74:20: note: called from here
    std.debug.print("{s} {s} / ", .{ first_line1, first_line2 });
                   ^
./exercises/050_no_value.zig:67:20: note: called from here
pub fn main() void {
                   ^
050_no_value.zig: The following command exited with error code 1:
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/zig build-exe /Users/jtgoen/code/zig/ziglings/exercises/050_no_value.zig --cache-dir /Users/jtgoen/code/zig/ziglings/zig-cache --enable-cache 

Edit exercises/050_no_value.zig and run this again.
To continue from this zigling, use this command:
    zig build 50
```

Error output from previously working solution for 082:
Previously Working Solution: [082_anonymous_structs3.zig.txt](https://github.com/ratfactor/ziglings/files/9215022/082_anonymous_structs3.zig.txt)
```shell
> zig build 82
Compiling 082_anonymous_structs3.zig...
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:458:5: error: invalid format string 's' for type 'type'
    @compileError("invalid format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
    ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:710:51: note: called from here
            if (actual_fmt.len != 0) invalidFmtErr(fmt, value);
                                                  ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:183:23: note: called from here
        try formatType(
                      ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/io/writer.zig:28:34: note: called from here
            return std.fmt.format(self, format, args);
                                 ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/debug.zig:93:27: note: called from here
    nosuspend stderr.print(fmt, args) catch return;
                          ^
./exercises/082_anonymous_structs3.zig:119:14: note: called from here
        print("\"{s}\"({s}):{any} ", .{
             ^
./exercises/082_anonymous_structs3.zig:50:15: note: called from here
    printTuple(foo);
              ^
./exercises/082_anonymous_structs3.zig:40:20: note: called from here
pub fn main() void {
                   ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:458:5: error: invalid format string 's' for type 'type'
    @compileError("invalid format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
    ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:710:51: note: called from here
            if (actual_fmt.len != 0) invalidFmtErr(fmt, value);
                                                  ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:183:23: note: called from here
        try formatType(
                      ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/io/writer.zig:28:34: note: called from here
            return std.fmt.format(self, format, args);
                                 ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/debug.zig:93:27: note: called from here
    nosuspend stderr.print(fmt, args) catch return;
                          ^
./exercises/082_anonymous_structs3.zig:119:14: note: called from here
        print("\"{s}\"({s}):{any} ", .{
             ^
./exercises/082_anonymous_structs3.zig:50:15: note: called from here
    printTuple(foo);
              ^
./exercises/082_anonymous_structs3.zig:40:20: note: called from here
pub fn main() void {
                   ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:458:5: error: invalid format string 's' for type 'type'
    @compileError("invalid format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
    ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:710:51: note: called from here
            if (actual_fmt.len != 0) invalidFmtErr(fmt, value);
                                                  ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/fmt.zig:183:23: note: called from here
        try formatType(
                      ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/io/writer.zig:28:34: note: called from here
            return std.fmt.format(self, format, args);
                                 ^
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/lib/zig/std/debug.zig:93:27: note: called from here
    nosuspend stderr.print(fmt, args) catch return;
                          ^
./exercises/082_anonymous_structs3.zig:119:14: note: called from here
        print("\"{s}\"({s}):{any} ", .{
             ^
./exercises/082_anonymous_structs3.zig:50:15: note: called from here
    printTuple(foo);
              ^
./exercises/082_anonymous_structs3.zig:40:20: note: called from here
pub fn main() void {
                   ^
082_anonymous_structs3.zig: The following command exited with error code 1:
/path/to/zig-macos-aarch64-0.10.0-dev.3362+e863292fe/zig build-exe /Users/jtgoen/code/zig/ziglings/exercises/082_anonymous_structs3.zig --cache-dir /Users/jtgoen/code/zig/ziglings/zig-cache --enable-cache 

HINT: This one is a challenge! But you have everything you need.
Edit exercises/082_anonymous_structs3.zig and run this again.
To continue from this zigling, use this command:
    zig build 82
```