### PR TITLE
Remove parameter in call to NativeTargetInfo.detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Verify the installation and build number of `zig` like so:
 
 ```bash
 $ zig version
-0.10.0-dev.3880+xxxxxxxxx
+0.10.0-dev.3952+xxxxxxxxx
 ```
 
 Clone this repository with Git:
@@ -81,6 +81,8 @@ about input:
 
 ### Version Changes
 
+* *2022-09-09* zig 0.10.0-dev.3952 - remove an Allocator parameter to the
+`NativeTargetInfo.detect` function.
 * *2022-09-06* zig 0.10.0-dev.3880 - Ex 074 correctly fails again: comptime array len
 * *2022-08-29* zig 0.10.0-dev.3685 - @typeName() output change, stage1 req. for async
 * *2022-07-31* zig 0.10.0-dev.3385 - std lib string fmt() option changes

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ const print = std.debug.print;
 // When changing this version, be sure to also update README.md in two places:
 //     1) Getting Started
 //     2) Version Changes
-const needed_version = std.SemanticVersion.parse("0.10.0-dev.3880") catch unreachable;
+const needed_version = std.SemanticVersion.parse("0.10.0-dev.3952") catch unreachable;
 
 const Exercise = struct {
     /// main_file must have the format key_name.zig.
@@ -754,7 +754,6 @@ const ZiglingStep = struct {
         const build_output_dir = std.mem.trimRight(u8, output_dir_nl, "\r\n");
 
         const target_info = std.zig.system.NativeTargetInfo.detect(
-            builder.allocator,
             .{},
         ) catch unreachable;
         const target = target_info.target;


### PR DESCRIPTION
Make ziglings build again :) Compatibility with ziglang/zig@3ee01c14ee7ba42b484f15daeacb67da90a81c9e, which states:

> This commit also solves a TODO to remove an Allocator parameter to the
> detect() function.