### PR TITLE
update build.zig for 0.10.0-dev.3978+xxxxxxxxx

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Verify the installation and build number of `zig` like so:
 
 ```bash
 $ zig version
-0.10.0-dev.3880+xxxxxxxxx
+0.10.0-dev.3978+xxxxxxxxx
 ```
 
 Clone this repository with Git:

--- a/build.zig
+++ b/build.zig
@@ -754,8 +754,7 @@ const ZiglingStep = struct {
         const build_output_dir = std.mem.trimRight(u8, output_dir_nl, "\r\n");
 
         const target_info = std.zig.system.NativeTargetInfo.detect(
-            builder.allocator,
-            .{},
+            .{}
         ) catch unreachable;
         const target = target_info.target;
 


### PR DESCRIPTION
When i try to build using 0.10.0-dev.3978+4fd4c733d version zig. it doesnt work well. Made a minor change to allow build.zig to compile

- Adding Support for 0.10.0-dev.3978+xxxxxxxxx