### PR TITLE
Exercise 82: typo and type fixes in comment

### DIFF
--- a/exercises/082_anonymous_structs3.zig
+++ b/exercises/082_anonymous_structs3.zig
@@ -4,8 +4,8 @@
 //
 //     .{
 //         false,
-//         @as(u32, 15);
-//         @as(i64, 67.12);
+//         @as(u32, 15),
+//         @as(f64, 67.12)
 //     }
 //
 // We call these "tuples", which is a term used by many


### PR DESCRIPTION
The comment at the top of exercise 82 has semicolons instead of commas in the tuple, and also tries to coerce a float into an integer, so changed `i64` to `f64`.

Also a big thank you for putting this together -- the exercises are really well written and provide such a good feature tour!