### PR TITLE
Exercise 60: mention new float type f80

### DIFF
--- a/exercises/060_floats.zig
+++ b/exercises/060_floats.zig
@@ -1,7 +1,7 @@
 //
 // Zig has support for IEEE-754 floating-point numbers in these
-// specific sizes: f16, f32, f64, f128. Floating point literals
-// may be writen in scientific notation:
+// specific sizes: f16, f32, f64, f80, and f128. Floating point
+// literals may be writen in scientific notation:
 //
 //     const a1: f32 = 1200.0;     // 1,200
 //     const a2: f32 = 1.2e+3;     // 1,200


### PR DESCRIPTION
As Zig 0.11 has added an f80 type, I thought it would be a good idea to mention it in the exercise.