### PR TITLE
(65, 71, 82): std.builtin.StructField field_type -> type rename

### DIFF
--- a/exercises/065_builtins2.zig
+++ b/exercises/065_builtins2.zig
@@ -100,7 +100,7 @@ pub fn main() void {
     //
     //     pub const StructField = struct {
     //         name: []const u8,
-    //         field_type: type,
+    //         type: type,
     //         default_value: anytype,
     //         is_comptime: bool,
     //         alignment: comptime_int,

--- a/exercises/071_comptime6.zig
+++ b/exercises/071_comptime6.zig
@@ -41,7 +41,7 @@ pub fn main() void {
     const fields = @typeInfo(Narcissus).Struct.fields;
 
     ??? {
-        if (field.field_type != void) {
+        if (field.type != void) {
             print(" {s}", .{field.name});
         }
     }

--- a/exercises/082_anonymous_structs3.zig
+++ b/exercises/082_anonymous_structs3.zig
@@ -96,7 +96,7 @@ fn printTuple(tuple: anytype) void {
         //
         //         pub const StructField = struct {
         //             name: []const u8,
-        //             field_type: type,
+        //             type: type,
         //             default_value: anytype,
         //             is_comptime: bool,
         //             alignment: comptime_int,

--- a/patches/patches/065_builtins2.patch
+++ b/patches/patches/065_builtins2.patch
@@ -6,7 +6,7 @@
      narcissus.me = &narcissus;
 -    narcissus.??? = ???;
 +    narcissus.myself = &narcissus;
- 
+
      // This determines a "peer type" from three separate
      // references (they just happen to all be the same object).
 @@ -70,7 +70,7 @@
@@ -15,7 +15,7 @@
      // difference!
 -    const Type2 = narcissus.fetchTheMostBeautifulType();
 +    const Type2 = Narcissus.fetchTheMostBeautifulType();
- 
+
      // Now we print a pithy statement about Narcissus.
      print("A {s} loves all {s}es. ", .{
 @@ -109,15 +109,15 @@
@@ -23,17 +23,17 @@
      // name will not be printed if the field is of type 'void'
      // (which is a zero-bit type that takes up no space at all!):
 -    if (fields[0].??? != void) {
-+    if (fields[0].field_type != void) {
++    if (fields[0].type != void) {
          print(" {s}", .{@typeInfo(Narcissus).Struct.fields[0].name});
      }
- 
+
 -    if (fields[1].??? != void) {
-+    if (fields[1].field_type != void) {
++    if (fields[1].type != void) {
          print(" {s}", .{@typeInfo(Narcissus).Struct.fields[1].name});
      }
- 
+
 -    if (fields[2].??? != void) {
-+    if (fields[2].field_type != void) {
++    if (fields[2].type != void) {
          print(" {s}", .{@typeInfo(Narcissus).Struct.fields[2].name});
      }
- 
+

--- a/patches/patches/082_anonymous_structs3.patch
+++ b/patches/patches/082_anonymous_structs3.patch
@@ -12,5 +12,5 @@
 <             ???,
 ---
 >             field.name,
->             field.field_type,
+>             field.type,
 >             @field(tuple, field.name),


### PR DESCRIPTION
Working through the exercises with a recent build of Zig from master, I ran into issues in `065_builtins2` (and 71 & 82) because it seems like with [this pull request](https://github.com/ziglang/zig/pull/13930) in Zig, `std.builtin.StructField`'s `field_type` member as been renamed to just `type`.

Thank you so much for this repository! 