### PR TITLE
build: fix build for latest zig version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -565,20 +565,7 @@ pub fn build(b: *Builder) void {
         reset_text = "\x1b[0m";
     }
 
-    const header_step = b.addLog(
-        \\
-        \\         _       _ _
-        \\     ___(_) __ _| (_)_ __   __ _ ___
-        \\    |_  | |/ _' | | | '_ \ / _' / __|
-        \\     / /| | (_| | | | | | | (_| \__ \
-        \\    /___|_|\__, |_|_|_| |_|\__, |___/
-        \\           |___/           |___/
-        \\
-        \\
-    , .{});
-
     const verify_all = b.step("ziglings", "Check all ziglings");
-    verify_all.dependOn(&header_step.step);
     b.default_step = verify_all;
 
     var prev_chain_verify = verify_all;
@@ -614,7 +601,6 @@ pub fn build(b: *Builder) void {
         chain_verify.dependOn(&verify_step.step);
 
         const named_chain = b.step(b.fmt("{s}_start", .{key}), b.fmt("Check all solutions starting at {s}", .{ex.main_file}));
-        named_chain.dependOn(&header_step.step);
         named_chain.dependOn(chain_verify);
 
         prev_chain_verify.dependOn(chain_verify);


### PR DESCRIPTION
Currently, you can't build ziglings from zig's master branch (at the time of writing, https://github.com/ziglang/zig/commit/c31007bb47a4d1d62917324a33e9a9a6cd1df5a6 is master's HEAD) 
This patch set adapts ziglings' build code to reflect the changes on latest zig version.   


---
A large and impactful change was made on zig's build facilities. The following PR https://github.com/ziglang/zig/pull/14647 introduced those changes.

To be more precise, here are the impacts
* the color handling on tty
* the removal of the LogStep logic