### PR TITLE
Update the code to the new zig version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Verify the installation and build number of `zig` like so:
 
 ```bash
 $ zig version
-0.11.0-dev.2401+xxxxxxxxx
+0.11.0-dev.2560+xxxxxxxxx
 ```
 
 Clone this repository with Git:
@@ -80,7 +80,8 @@ about input:
 
 ### Version Changes
 
-Version-0.11.0-dev.2401+xxxxxxxxx
+Version-0.11.0-dev.2560+602029bb2
+* *2023-04-07* zig 0.11.0-dev.2401 - fixes of the new build system - #212
 * *2023-02-21* zig 0.11.0-dev.2157 - changes in `build system` - new: parallel processing of the build steps
 * *2023-02-21* zig 0.11.0-dev.1711 - changes in `for loops` - new: Multi-Object For-Loops + Struct-of-Arrays
 * *2023-02-12* zig 0.11.0-dev.1638 - changes in `std.Build` cache_root now returns a directory struct

--- a/build.zig
+++ b/build.zig
@@ -575,9 +575,9 @@ pub fn build(b: *Build) !void {
         if (ex.C) {
             build_step.linkLibC();
         }
-        build_step.install();
+        b.installArtifact(build_step);
 
-        const run_step = build_step.run();
+        const run_step = b.addRunArtifact(build_step);
 
         const test_step = b.step("test", b.fmt("Run {s} without checking output", .{ex.main_file}));
         if (ex.skip) {
@@ -628,9 +628,9 @@ pub fn build(b: *Build) !void {
             if (ex.C) {
                 build_step.linkLibC();
             }
-            build_step.install();
+            b.installArtifact(build_step);
 
-            const run_step = build_step.run();
+            const run_step = b.addRunArtifact(build_step);
             if (ex.skip) {
                 const skip_step = SkipStep.create(b, ex);
                 test_step.dependOn(&skip_step.step);
@@ -655,7 +655,7 @@ pub fn build(b: *Build) !void {
         }) catch unreachable;
 
         const build_step = b.addExecutable(.{ .name = base_name, .root_source_file = .{ .path = file_path } });
-        build_step.install();
+        b.installArtifact(build_step);
 
         const verify_stepn = ZiglingStep.create(b, ex, use_healed);
         verify_stepn.step.dependOn(prev_step);

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -15,7 +15,7 @@ const print = if (@hasDecl(debug, "print")) debug.print else debug.warn;
 // When changing this version, be sure to also update README.md in two places:
 //     1) Getting Started
 //     2) Version Changes
-const needed_version_str = "0.11.0-dev.2401";
+const needed_version_str = "0.11.0-dev.2560";
 
 fn isCompatible() bool {
     if (!@hasDecl(builtin, "zig_version") or !@hasDecl(std, "SemanticVersion")) {


### PR DESCRIPTION
Update the code to the breaking change in ziglang commit 60eabc0ec (std.Build.CompileStep: remove run() and install())

Update the zig version in the README.md file.