### PR TITLE
Automatically resume from last completed exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 zig-cache/
 answers/
 patches/healed/
+completed_to.txt


### PR DESCRIPTION
Instead of having to `zig build -Dn=19 start` this automatically tracks your most recently completed exercise by writing a file named `completed_to.txt` so you don't have to keep building and testing all the previously completed exercises.

Warning: I'm a complete Zig noob just playing around so this may not be idiomatic at all