### PR TITLE
workflows: improve the jobs configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 defaults:
   run:
     shell: bash
+  strategy:
+    fail-fast: false
+  timeout-minutes: 30
 
 jobs:
   compat:
@@ -28,7 +31,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/eowyn.yml
+++ b/.github/workflows/eowyn.yml
@@ -9,6 +9,9 @@ on:
 defaults:
   run:
     shell: bash
+  strategy:
+    fail-fast: false
+  timeout-minutes: 30
 
 jobs:
   build:
@@ -16,9 +19,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
+
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:

--- a/.github/workflows/eowyn.yml
+++ b/.github/workflows/eowyn.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
 
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2


### PR DESCRIPTION
Reduce the timeout to 30 minutes for all the jobs, since it is enough.

Set strategy.fail-fast to false, so that we can see the full logs.