### PR TITLE
workflows: restore the workflows configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,16 @@ on:
 defaults:
   run:
     shell: bash
-  strategy:
-    fail-fast: false
-  timeout-minutes: 30
 
 jobs:
   compat:
+    name: Compatibility Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         zig: [ 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0 ]
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 
@@ -27,17 +27,20 @@ jobs:
     - name: Check compatibility with old Zig compilers
       run: ci/compat.sh
   test:
+    name: Unit Test
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
         version: master
 
-    - name: Unit Test
+    - name: Run unit tests
       run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/eowyn.yml
+++ b/.github/workflows/eowyn.yml
@@ -12,13 +12,16 @@ defaults:
 
 jobs:
   build:
+    name: Build
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:


### PR DESCRIPTION
After #259, with a bug in workflow files, was merged, the successive commits did not fully restored the original state

In ci.yml:
  - Remove the incorrect default configuration
  - Reduce the timeout to 30 minutes for all the jobs, since it is enough
  - Add a name to all the jobs

In both ci.yml and eowyn.yml:
  - Set strategy.fail-fast to false, so that we can read the logs
  - Sort field names in lexicographical order
  - Update again to actions/checkout@v3