### PR TITLE
Fix deadlock on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-name: 'CI'
-# Makes some checks
+name: CI
 
 on:
   pull_request:
@@ -27,29 +26,13 @@ jobs:
 
       - name: Check compatibility with old Zig compilers
         run: ci/compat.sh
-      
-  test-linux_mac:
+
+  test:
     name: Unit Tests
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: master
-
-      - name: Run unit tests
-        run: zig build test
-        
-  test-windows:
-    name: Unit Test Windows
-    runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/eowyn.yml
+++ b/.github/workflows/eowyn.yml
@@ -1,5 +1,5 @@
-name: 'Eowyn'
-# Tests all exercises
+# Test that exercises work with the latest Zig compiler.
+name: Eowyn
 
 on:
   pull_request:
@@ -13,35 +13,20 @@ defaults:
     shell: bash
 
 jobs:
-  build-linux_mac:
+  build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
           version: master
-          
-      - name: Run Eowyn
-        run: patches/eowyn.sh
-        
-  build-windows:
-    runs-on: windows-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        
-      - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: master
-          
+
       - name: Run Eowyn
         run: patches/eowyn.sh

--- a/patches/eowyn.sh
+++ b/patches/eowyn.sh
@@ -45,13 +45,8 @@ do
     fi
 done
 
-# Test the correct formatting of the healed exercises.
 echo "Looking for non-conforming code formatting..."
-for healed in patches/healed/*.zig
-do
-	echo Check $(basename "$healed")
-	zig fmt --check "$healed"
-done
+zig fmt --check patches/healed
 
 # Test the healed exercises. May the compiler have mercy upon us.
 zig build -Dhealed

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -336,7 +336,6 @@ fn heal(allocator: Allocator, exercises: []const Exercise, outdir: []const u8) !
         const argv = &.{ "patch", "-i", patch, "-o", output, file };
 
         var child = std.process.Child.init(argv, allocator);
-        child.stdout_behavior = .Ignore; // the POSIX standard says that stdout is not used
         _ = try child.spawnAndWait();
     }
 }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -333,7 +333,7 @@ fn heal(allocator: Allocator, exercises: []const Exercise, outdir: []const u8) !
         };
         const output = try join(allocator, &.{ outdir, ex.main_file });
 
-        const argv = &.{ "patch", "-i", patch, "-o", output, file };
+        const argv = &.{ "patch", "-i", patch, "-o", output, "-s", file };
 
         var child = std.process.Child.init(argv, allocator);
         _ = try child.spawnAndWait();


### PR DESCRIPTION
Let me know if you find some problems.

With the additional commits everything seems ok to me.

The unit test jobs use the cache filled by the eowyn jobs; not sure if this is the correct thing to do but it helps reduce the running time.

UPDATE: there was an error in https://github.com/ratfactor/ziglings/actions/runs/4839360264/jobs/8624337146.