### PR TITLE
Don't reheal exercises (skip redundant patching) [Issue #272] 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,21 @@ jobs:
       - name: Check compatibility with old Zig compilers
         run: ci/compat.sh
 
-#  test:
-#    name: Unit Tests
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest, windows-latest, macos-latest]
-#    runs-on: ${{ matrix.os }}
-#    timeout-minutes: 30
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Setup Zig
-#        uses: goto-bus-stop/setup-zig@v2
-#        with:
-#          version: master
-#
-#      - name: Run unit tests
-#        run: zig build test
+  test:
+    name: Unit Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: master
+
+      - name: Run unit tests
+        run: zig build test

--- a/build.zig
+++ b/build.zig
@@ -210,9 +210,8 @@ pub fn build(b: *Build) !void {
     }
     ziglings_step.dependOn(prev_step);
 
-    // Disabled, see issue 272
-    // const test_step = b.step("test", "Run all the tests");
-    // // test_step.dependOn(tests.addCliTests(b, &exercises));
+    const test_step = b.step("test", "Run all the tests");
+    test_step.dependOn(tests.addCliTests(b, &exercises));
 }
 
 var use_color_escapes = false;

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -333,7 +333,8 @@ fn heal(allocator: Allocator, exercises: []const Exercise, outdir: []const u8) !
         };
         const output = try join(allocator, &.{ outdir, ex.main_file });
 
-        const argv = &.{ "patch", "-i", patch, "-o", output, "-s", file };
+        // `-N` flag passed to address UX issue #272.
+        const argv = &.{ "patch", "-i", patch, "-o", output, "-s", "-N", file };
 
         var child = std.process.Child.init(argv, allocator);
         _ = try child.spawnAndWait();


### PR DESCRIPTION
Possibly less intrusive approach to solve UX issue #272  with running `zig build` repeatedly while advancing through exercises. Approach is to tell patch command (by passing the `-N` flag) that we will just ignore redundant patching on top of exercises solved by the user.

From `man patch`:
```
-N, --forward
        Causes patch to ignore patches that it thinks are reversed or already applied.  See also -R.
```