### PR TITLE
Refactor ZiglingStep

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -395,7 +395,16 @@ const ZiglingStep = struct {
                     for (argv) |v| print("{s} ", .{v});
                     print("\n", .{});
                 },
-                else => {},
+                else => {
+                    print("{s}{s}: Unexpected error: {s}{s}\n", .{
+                        red_text,
+                        self.exercise.main_file,
+                        @errorName(err),
+                        reset_text,
+                    });
+                    for (argv) |v| print("{s} ", .{v});
+                    print("\n", .{});
+                },
             }
 
             return err;

--- a/build.zig
+++ b/build.zig
@@ -228,8 +228,8 @@ const ZiglingStep = struct {
     result_messages: []const u8 = "",
     result_error_bundle: std.zig.ErrorBundle = std.zig.ErrorBundle.empty,
 
-    pub fn create(builder: *Build, exercise: Exercise, work_path: []const u8) *@This() {
-        const self = builder.allocator.create(@This()) catch unreachable;
+    pub fn create(builder: *Build, exercise: Exercise, work_path: []const u8) *ZiglingStep {
+        const self = builder.allocator.create(ZiglingStep) catch unreachable;
         self.* = .{
             .step = Step.init(Step.Options{ .id = .custom, .name = exercise.main_file, .owner = builder, .makeFn = make }),
             .exercise = exercise,
@@ -239,7 +239,7 @@ const ZiglingStep = struct {
     }
 
     fn make(step: *Step, prog_node: *std.Progress.Node) !void {
-        const self = @fieldParentPtr(@This(), "step", step);
+        const self = @fieldParentPtr(ZiglingStep, "step", step);
 
         if (self.exercise.skip) {
             print("Skipping {s}\n\n", .{self.exercise.main_file});
@@ -266,7 +266,7 @@ const ZiglingStep = struct {
         };
     }
 
-    fn run(self: *@This(), exe_path: []const u8, _: *std.Progress.Node) !void {
+    fn run(self: *ZiglingStep, exe_path: []const u8, _: *std.Progress.Node) !void {
         resetLine();
         print("Checking {s}...\n", .{self.exercise.main_file});
 
@@ -326,7 +326,7 @@ const ZiglingStep = struct {
         print("{s}PASSED:\n{s}{s}\n\n", .{ green_text, trimOutput, reset_text });
     }
 
-    fn compile(self: *@This(), prog_node: *std.Progress.Node) ![]const u8 {
+    fn compile(self: *ZiglingStep, prog_node: *std.Progress.Node) ![]const u8 {
         print("Compiling {s}...\n", .{self.exercise.main_file});
 
         const b = self.step.owner;

--- a/build.zig
+++ b/build.zig
@@ -223,7 +223,6 @@ var reset_text: []const u8 = "";
 const ZiglingStep = struct {
     step: Step,
     exercise: Exercise,
-    builder: *Build,
     work_path: []const u8,
 
     result_messages: []const u8 = "",
@@ -234,7 +233,6 @@ const ZiglingStep = struct {
         self.* = .{
             .step = Step.init(Step.Options{ .id = .custom, .name = exercise.main_file, .owner = builder, .makeFn = make }),
             .exercise = exercise,
-            .builder = builder,
             .work_path = work_path,
         };
         return self;
@@ -331,12 +329,12 @@ const ZiglingStep = struct {
     fn compile(self: *@This(), prog_node: *std.Progress.Node) ![]const u8 {
         print("Compiling {s}...\n", .{self.exercise.main_file});
 
-        const builder = self.builder;
+        const b = self.step.owner;
 
-        var zig_args = std.ArrayList([]const u8).init(builder.allocator);
+        var zig_args = std.ArrayList([]const u8).init(b.allocator);
         defer zig_args.deinit();
 
-        zig_args.append(builder.zig_exe) catch unreachable;
+        zig_args.append(b.zig_exe) catch unreachable;
         zig_args.append("build-exe") catch unreachable;
 
         // Enable C support for exercises that use C functions
@@ -344,11 +342,11 @@ const ZiglingStep = struct {
             zig_args.append("-lc") catch unreachable;
         }
 
-        const zig_file = join(builder.allocator, &.{ self.work_path, self.exercise.main_file }) catch unreachable;
-        zig_args.append(builder.pathFromRoot(zig_file)) catch unreachable;
+        const zig_file = join(b.allocator, &.{ self.work_path, self.exercise.main_file }) catch unreachable;
+        zig_args.append(b.pathFromRoot(zig_file)) catch unreachable;
 
         zig_args.append("--cache-dir") catch unreachable;
-        zig_args.append(builder.pathFromRoot(builder.cache_root.path.?)) catch unreachable;
+        zig_args.append(b.pathFromRoot(b.cache_root.path.?)) catch unreachable;
 
         zig_args.append("--listen=-") catch unreachable;
 

--- a/build.zig
+++ b/build.zig
@@ -313,11 +313,11 @@ const ZiglingStep = struct {
         if (!std.mem.eql(u8, trimOutput, trimExerciseOutput)) {
             print(
                 \\
-                \\{s}----------- Expected this output -----------{s}
-                \\"{s}"
-                \\{s}----------- but found -----------{s}
-                \\"{s}"
-                \\{s}-----------{s}
+                \\{s}========= expected this output: =========={s}
+                \\{s}
+                \\{s}========= but found: ====================={s}
+                \\{s}
+                \\{s}=========================================={s}
                 \\
             , .{ red_text, reset_text, trimExerciseOutput, red_text, reset_text, trimOutput, red_text, reset_text });
             return error.InvalidOutput;

--- a/build.zig
+++ b/build.zig
@@ -229,7 +229,7 @@ const ZiglingStep = struct {
     result_error_bundle: std.zig.ErrorBundle = std.zig.ErrorBundle.empty,
 
     pub fn create(builder: *Build, exercise: Exercise, work_path: []const u8) *ZiglingStep {
-        const self = builder.allocator.create(ZiglingStep) catch unreachable;
+        const self = builder.allocator.create(ZiglingStep) catch @panic("OOM");
         self.* = .{
             .step = Step.init(Step.Options{ .id = .custom, .name = exercise.main_file, .owner = builder, .makeFn = make }),
             .exercise = exercise,
@@ -334,21 +334,21 @@ const ZiglingStep = struct {
         var zig_args = std.ArrayList([]const u8).init(b.allocator);
         defer zig_args.deinit();
 
-        zig_args.append(b.zig_exe) catch unreachable;
-        zig_args.append("build-exe") catch unreachable;
+        zig_args.append(b.zig_exe) catch @panic("OOM");
+        zig_args.append("build-exe") catch @panic("OOM");
 
         // Enable C support for exercises that use C functions
         if (self.exercise.link_libc) {
-            zig_args.append("-lc") catch unreachable;
+            zig_args.append("-lc") catch @panic("OOM");
         }
 
-        const zig_file = join(b.allocator, &.{ self.work_path, self.exercise.main_file }) catch unreachable;
-        zig_args.append(b.pathFromRoot(zig_file)) catch unreachable;
+        const zig_file = join(b.allocator, &.{ self.work_path, self.exercise.main_file }) catch @panic("OOM");
+        zig_args.append(b.pathFromRoot(zig_file)) catch @panic("OOM");
 
-        zig_args.append("--cache-dir") catch unreachable;
-        zig_args.append(b.pathFromRoot(b.cache_root.path.?)) catch unreachable;
+        zig_args.append("--cache-dir") catch @panic("OOM");
+        zig_args.append(b.pathFromRoot(b.cache_root.path.?)) catch @panic("OOM");
 
-        zig_args.append("--listen=-") catch unreachable;
+        zig_args.append("--listen=-") catch @panic("OOM");
 
         const argv = zig_args.items;
         var code: u8 = undefined;


### PR DESCRIPTION
Update and improve the code in `ZiglingStep`

  - [x] Remove `makeInternal()`, rename `doCompile()` to `compile()` and add `run()`.
         Now `compile()` and `run()` are called one after another in `make()`.
  - [x] Ensure to print an error message for **all** errors
  - [x] Simply use `Child.exec` to run the exercise
  - [x] Improve the exercise output check, making the diff consistent with the one implemented in `std.Build.RunStep`.
  - [x] Improve coding style, making it consistent with the coding style in `std.Build`.
         Also, try to avoid lines too long.