### PR TITLE
Add the -Dhealed-path option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -118,11 +118,12 @@ pub fn build(b: *Build) !void {
         \\
     ;
 
-    const use_healed = b.option(bool, "healed", "Run exercises from patches/healed") orelse false;
+    const healed = b.option(bool, "healed", "Run exercises from patches/healed") orelse false;
+    const override_healed_path = b.option([]const u8, "healed-path", "Override healed path");
     const exno: ?usize = b.option(usize, "n", "Select exercise");
 
-    const healed_path = "patches/healed";
-    const work_path = if (use_healed) healed_path else "exercises";
+    const healed_path = if (override_healed_path) |path| path else "patches/healed";
+    const work_path = if (healed) healed_path else "exercises";
 
     const header_step = PrintStep.create(b, logo);
 
@@ -168,7 +169,7 @@ pub fn build(b: *Build) !void {
         start_step.dependOn(&prev_step.step);
 
         return;
-    } else if (use_healed and false) {
+    } else if (healed and false) {
         // Special case when healed by the eowyn script, where we can make the
         // code more efficient.
         //

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -158,7 +158,7 @@ fn createCase(b: *Build, name: []const u8) *Step {
     return case_step;
 }
 
-// Check the output of `zig build` or `zig build -Dn=1 start`.
+/// Checks the output of `zig build` or `zig build -Dn=1 start`.
 const CheckStep = struct {
     step: Step,
     exercises: []const Exercise,
@@ -282,7 +282,7 @@ const CheckStep = struct {
     }
 };
 
-// A step that will fail.
+/// Fails with a custom error message.
 const FailStep = struct {
     step: Step,
     error_msg: []const u8,
@@ -311,9 +311,9 @@ const FailStep = struct {
     }
 };
 
-// A variant of `std.Build.Step.fail` that does not return an error so that it
-// can be used in the configuration phase.  It returns a FailStep, so that the
-// error will be cleanly handled by the build runner.
+/// A variant of `std.Build.Step.fail` that does not return an error so that it
+/// can be used in the configuration phase.  It returns a FailStep, so that the
+/// error will be cleanly handled by the build runner.
 fn fail(step: *Step, comptime format: []const u8, args: anytype) *Step {
     const b = step.owner;
 
@@ -323,7 +323,7 @@ fn fail(step: *Step, comptime format: []const u8, args: anytype) *Step {
     return step;
 }
 
-// A step that heals exercises.
+/// Heals the exercises.
 const HealStep = struct {
     step: Step,
     exercises: []const Exercise,
@@ -353,7 +353,7 @@ const HealStep = struct {
     }
 };
 
-// Heals all the exercises.
+/// Heals all the exercises.
 fn heal(allocator: Allocator, exercises: []const Exercise, work_path: []const u8) !void {
     const join = fs.path.join;
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -7,6 +7,7 @@ const fs = std.fs;
 const mem = std.mem;
 
 const Allocator = std.mem.Allocator;
+const Child = std.process.Child;
 const Build = std.build;
 const FileSource = std.Build.FileSource;
 const Reader = fs.File.Reader;
@@ -363,7 +364,6 @@ fn heal(allocator: Allocator, exercises: []const Exercise, work_path: []const u8
     for (exercises) |ex| {
         const name = ex.name();
 
-        // Use the POSIX patch variant.
         const file = try join(allocator, &.{ exercises_path, ex.main_file });
         const patch = b: {
             const patch_name = try fmt.allocPrint(allocator, "{s}.patch", .{name});
@@ -373,7 +373,7 @@ fn heal(allocator: Allocator, exercises: []const Exercise, work_path: []const u8
 
         const argv = &.{ "patch", "-i", patch, "-o", output, "-s", file };
 
-        var child = std.process.Child.init(argv, allocator);
+        var child = Child.init(argv, allocator);
         _ = try child.spawnAndWait();
     }
 }


### PR DESCRIPTION
The use of the new option will improve the unit tests, since now each test case can use a different exercises directory.

It will also prevent the unit tests to modify the ziglings project working directory (creating the `patches/healed` directory and not removing it).

In `build.zig`, renamed `use_healed` to `healed`.