### PR TITLE
Add the find-zig-release-branch.sh tool

### DIFF
--- a/tools/find-zig-release-branch.sh
+++ b/tools/find-zig-release-branch.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Find the latest commit that is compatible with a specified Zig version, like
+# 0.10.1.
+#
+# The zig executable can be set using the ZIG_EXE environment variable.
+#
+# This script will clone the ziglings repository to the path specified by the
+# first parameter, that is required.  Commits are processed in date order.
+
+# Heals all the exercises.
+heal() {
+    if [ ! -d exercises ]
+    then
+        echo "Must be run from the project root directory."
+        exit 1
+    fi
+
+    mkdir -p patches/healed
+    for original in exercises/*.zig; do
+        name=$(basename "$original" .zig)
+        patch_name="patches/patches/$name.patch"
+        output="patches/healed/$name.zig"
+
+        if [ -f "$patch_name" ]; then
+            patch -i "$patch_name" -o "$output" -s "$original"
+        else
+            printf "Cannot heal %s: no patch found\n" "$name"
+        fi
+    done
+}
+
+# Configure input parameters.
+if [ -z "$ZIG_EXE" ]; then
+    echo '$ZIG_EXE is required'
+    exit 1
+fi
+
+work_path="$1"
+if [ -z "$work_path" ] ; then
+    echo "The work_path parameter is required and must be a directory"
+    exit 1
+elif [ ! -d "$work_path" ]; then
+    printf "%s does not exist\n" "$work_path"
+    exit 1
+fi
+
+# Clone ziglings repository.
+cd "$work_path" || exit 1
+echo "Cloning into 'ziglings'"
+git clone -q https://github.com/ratfactor/ziglings.git ziglings || exit 1
+
+# Find a commit compatible with the specified Zig version.
+cd ziglings || exit 1
+for commit in $(git log --date-order --pretty=format:"%H"); do
+    git checkout --detach -q "$commit"
+    printf "\nTesting commit %s\n" "$commit"
+
+    heal
+
+    # Some versions exits with exit code 0 instead of 1, if version check fails.
+    sed -i 's/exit(0)/exit(1)/g' build.zig
+
+    "$ZIG_EXE" build -Dhealed
+    zig_ret=$?
+
+    git restore build.zig
+
+    if [ "$zig_ret" -eq 0 ]; then
+        printf "Find working commit: %s\n" "$commit"
+        exit 0
+    fi
+done


### PR DESCRIPTION
The tool is used to find the latest commit, from the HEAD in date order, that is compatible with the specified Zig compiler.

The commit found can be used as a base for a branch that can be used by users that can only install a released version of Zig, e.g. v0.10.1.

I implemented this tool because there is already a `v0.8.1` branch, but I'm not sure there are people that may use a `v0.10.1` branch.

Here is an example usage:
```sh
ZIG_EXE=~/.local/share/sdk/zig/0.10.1/zig ./tools/find-zig-release-branch.sh /tmp
```

The commit found is: cea631bf7f10e0c8648f561f2f418ac3eb060901 or `main~111`.

@ratfactor, @chrboesch  What do think?

Note that the script will clone https://github.com/ratfactor/ziglings.git.
Make sure to double check that the commit is really compatible!