### PR TITLE
Simplify build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -194,20 +194,13 @@ pub fn build(b: *Build) !void {
         return;
     }
 
-    // Run all exercises in a row
+    // Normal build mode: verifies all exercises according to the recommended
+    // order.
     const ziglings_step = b.step("ziglings", "Check all ziglings");
     b.default_step = ziglings_step;
 
     var prev_step = &header_step.step;
     for (exercises) |ex| {
-        const build_step = ex.addExecutable(b, work_path);
-
-        const skip_step = SkipStep.create(b, ex);
-        if (!ex.skip)
-            b.installArtifact(build_step)
-        else
-            b.getInstallStep().dependOn(&skip_step.step);
-
         const verify_stepn = ZiglingStep.create(b, ex, work_path);
         verify_stepn.step.dependOn(prev_step);
 

--- a/build.zig
+++ b/build.zig
@@ -119,6 +119,9 @@ pub fn build(b: *Build) !void {
         reset_text = "\x1b[0m";
     }
 
+    // Remove the standard install and uninstall steps.
+    b.top_level_steps = .{};
+
     const healed = b.option(bool, "healed", "Run exercises from patches/healed") orelse
         false;
     const override_healed_path = b.option([]const u8, "healed-path", "Override healed path");

--- a/build.zig
+++ b/build.zig
@@ -136,7 +136,6 @@ pub fn build(b: *Build) !void {
 
     const header_step = PrintStep.create(b, logo);
 
-    // If the user pass a number for an exercise
     if (exno) |n| {
         // Named build mode: verifies a single exercise.
         if (n == 0 or n > exercises.len - 1) {

--- a/build.zig
+++ b/build.zig
@@ -192,29 +192,6 @@ pub fn build(b: *Build) !void {
         start_step.dependOn(&prev_step.step);
 
         return;
-    } else if (healed and false) {
-        // Special case when healed by the eowyn script, where we can make the
-        // code more efficient.
-        //
-        // TODO: this branch is disabled because it prevents the normal case to
-        // be executed.
-        const test_step = b.step("test", "Test the healed exercises");
-        b.default_step = test_step;
-
-        for (exercises) |ex| {
-            const build_step = ex.addExecutable(b, healed_path);
-            b.installArtifact(build_step);
-
-            const run_step = b.addRunArtifact(build_step);
-            if (ex.skip) {
-                const skip_step = SkipStep.create(b, ex);
-                test_step.dependOn(&skip_step.step);
-            } else {
-                test_step.dependOn(&run_step.step);
-            }
-        }
-
-        return;
     }
 
     // Run all exercises in a row

--- a/build.zig
+++ b/build.zig
@@ -153,8 +153,11 @@ pub fn build(b: *Build) !void {
             b.fmt("Check the solution of {s}", .{ex.main_file}),
         );
         b.default_step = zigling_step;
+        zigling_step.dependOn(&header_step.step);
 
         const verify_step = ZiglingStep.create(b, ex, work_path);
+        verify_step.step.dependOn(&header_step.step);
+
         zigling_step.dependOn(&verify_step.step);
 
         return;

--- a/build.zig
+++ b/build.zig
@@ -64,20 +64,6 @@ pub const Exercise = struct {
     pub fn number(self: Exercise) usize {
         return std.fmt.parseInt(usize, self.key(), 10) catch unreachable;
     }
-
-    /// Returns the CompileStep for this exercise.
-    ///
-    /// TODO: currently this method is no longer used.
-    pub fn addExecutable(self: Exercise, b: *Build, work_path: []const u8) *CompileStep {
-        const path = join(b.allocator, &.{ work_path, self.main_file }) catch
-            @panic("OOM");
-
-        return b.addExecutable(.{
-            .name = self.name(),
-            .root_source_file = .{ .path = path },
-            .link_libc = self.link_libc,
-        });
-    }
 };
 
 pub const logo =
@@ -640,35 +626,6 @@ const PrintStep = struct {
         const self = @fieldParentPtr(PrintStep, "step", step);
 
         print("{s}", .{self.message});
-    }
-};
-
-/// Skips an exercise.
-const SkipStep = struct {
-    step: Step,
-    exercise: Exercise,
-
-    pub fn create(owner: *Build, exercise: Exercise) *SkipStep {
-        const self = owner.allocator.create(SkipStep) catch @panic("OOM");
-        self.* = .{
-            .step = Step.init(.{
-                .id = .custom,
-                .name = owner.fmt("skip {s}", .{exercise.main_file}),
-                .owner = owner,
-                .makeFn = make,
-            }),
-            .exercise = exercise,
-        };
-
-        return self;
-    }
-
-    fn make(step: *Step, _: *std.Progress.Node) !void {
-        const self = @fieldParentPtr(SkipStep, "step", step);
-
-        if (self.exercise.skip) {
-            print("{s} skipped\n", .{self.exercise.main_file});
-        }
     }
 };
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -151,6 +151,16 @@ const CheckNamedStep = struct {
         defer stderr_file.close();
 
         const stderr = stderr_file.reader();
+        {
+            // Skip the logo.
+            const nlines = mem.count(u8, root.logo, "\n");
+            var buf: [80]u8 = undefined;
+
+            var lineno: usize = 0;
+            while (lineno < nlines) : (lineno += 1) {
+                _ = try readLine(stderr, &buf);
+            }
+        }
         try check_output(step, ex, stderr);
     }
 };

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -20,7 +20,7 @@ pub fn addCliTests(b: *std.Build, exercises: []const Exercise) *Step {
     const step = b.step("test-cli", "Test the command line interface");
 
     {
-        // Test that `zig build -Dhealed -Dn=n test` selects the nth exercise.
+        // Test that `zig build -Dhealed -Dn=n` selects the nth exercise.
         const case_step = createCase(b, "case-1");
 
         const tmp_path = makeTempPath(b) catch |err| {
@@ -31,7 +31,6 @@ pub fn addCliTests(b: *std.Build, exercises: []const Exercise) *Step {
 
         for (exercises[0 .. exercises.len - 1]) |ex| {
             const n = ex.number();
-            if (ex.skip) continue;
 
             const cmd = b.addSystemCommand(&.{
                 b.zig_exe,
@@ -39,18 +38,13 @@ pub fn addCliTests(b: *std.Build, exercises: []const Exercise) *Step {
                 "-Dhealed",
                 b.fmt("-Dhealed-path={s}", .{tmp_path}),
                 b.fmt("-Dn={}", .{n}),
-                "test",
             });
-            cmd.setName(b.fmt("zig build -Dhealed -Dn={} test", .{n}));
+            cmd.setName(b.fmt("zig build -Dhealed -Dn={}", .{n}));
             cmd.expectExitCode(0);
             cmd.step.dependOn(&heal_step.step);
 
-            const output = if (ex.check_stdout)
-                cmd.captureStdOut()
-            else
-                cmd.captureStdErr();
-
-            const verify = CheckNamedStep.create(b, ex, output);
+            const stderr = cmd.captureStdErr();
+            const verify = CheckNamedStep.create(b, ex, stderr);
             verify.step.dependOn(&cmd.step);
 
             case_step.dependOn(&verify.step);
@@ -63,47 +57,8 @@ pub fn addCliTests(b: *std.Build, exercises: []const Exercise) *Step {
     }
 
     {
-        // Test that `zig build -Dhealed -Dn=n test` skips disabled esercises.
+        // Test that `zig build -Dhealed` processes all the exercises in order.
         const case_step = createCase(b, "case-2");
-
-        const tmp_path = makeTempPath(b) catch |err| {
-            return fail(step, "unable to make tmp path: {s}\n", .{@errorName(err)});
-        };
-
-        const heal_step = HealStep.create(b, exercises, tmp_path);
-
-        for (exercises[0 .. exercises.len - 1]) |ex| {
-            const n = ex.number();
-            if (!ex.skip) continue;
-
-            const cmd = b.addSystemCommand(&.{
-                b.zig_exe,
-                "build",
-                "-Dhealed",
-                b.fmt("-Dhealed-path={s}", .{tmp_path}),
-                b.fmt("-Dn={}", .{n}),
-                "test",
-            });
-            const expect = b.fmt("{s} skipped", .{ex.main_file});
-            cmd.setName(b.fmt("zig build -Dhealed -Dn={} test", .{n}));
-            cmd.expectExitCode(0);
-            cmd.addCheck(.{ .expect_stdout_exact = "" });
-            cmd.addCheck(.{ .expect_stderr_match = expect });
-
-            cmd.step.dependOn(&heal_step.step);
-
-            case_step.dependOn(&cmd.step);
-        }
-
-        const cleanup = b.addRemoveDirTree(tmp_path);
-        cleanup.step.dependOn(case_step);
-
-        step.dependOn(&cleanup.step);
-    }
-
-    {
-        // Test that `zig build -Dhealed` process all the exercises in order.
-        const case_step = createCase(b, "case-3");
 
         const tmp_path = makeTempPath(b) catch |err| {
             return fail(step, "unable to make tmp path: {s}\n", .{@errorName(err)});
@@ -124,42 +79,7 @@ pub fn addCliTests(b: *std.Build, exercises: []const Exercise) *Step {
         cmd.step.dependOn(&heal_step.step);
 
         const stderr = cmd.captureStdErr();
-        const verify = CheckStep.create(b, exercises, stderr, true);
-        verify.step.dependOn(&cmd.step);
-
-        const cleanup = b.addRemoveDirTree(tmp_path);
-        cleanup.step.dependOn(&verify.step);
-
-        step.dependOn(&cleanup.step);
-    }
-
-    {
-        // Test that `zig build -Dhealed -Dn=1 start` process all the exercises
-        // in order.
-        const case_step = createCase(b, "case-4");
-
-        const tmp_path = makeTempPath(b) catch |err| {
-            return fail(step, "unable to make tmp path: {s}\n", .{@errorName(err)});
-        };
-
-        const heal_step = HealStep.create(b, exercises, tmp_path);
-        heal_step.step.dependOn(case_step);
-
-        // TODO: when an exercise is modified, the cache is not invalidated.
-        const cmd = b.addSystemCommand(&.{
-            b.zig_exe,
-            "build",
-            "-Dhealed",
-            b.fmt("-Dhealed-path={s}", .{tmp_path}),
-            "-Dn=1",
-            "start",
-        });
-        cmd.setName("zig build -Dhealed -Dn=1 start");
-        cmd.expectExitCode(0);
-        cmd.step.dependOn(&heal_step.step);
-
-        const stderr = cmd.captureStdErr();
-        const verify = CheckStep.create(b, exercises, stderr, false);
+        const verify = CheckStep.create(b, exercises, stderr);
         verify.step.dependOn(&cmd.step);
 
         const cleanup = b.addRemoveDirTree(tmp_path);
@@ -170,7 +90,7 @@ pub fn addCliTests(b: *std.Build, exercises: []const Exercise) *Step {
 
     {
         // Test that `zig build -Dn=1` prints the hint.
-        const case_step = createCase(b, "case-5");
+        const case_step = createCase(b, "case-3");
 
         const cmd = b.addSystemCommand(&.{ b.zig_exe, "build", "-Dn=1" });
         const expect = exercises[0].hint orelse "";
@@ -197,13 +117,13 @@ fn createCase(b: *Build, name: []const u8) *Step {
     return case_step;
 }
 
-/// Checks the output of `zig build -Dn=n test`.
+/// Checks the output of `zig build -Dn=n`.
 const CheckNamedStep = struct {
     step: Step,
     exercise: Exercise,
-    output: FileSource,
+    stderr: FileSource,
 
-    pub fn create(owner: *Build, exercise: Exercise, output: FileSource) *CheckNamedStep {
+    pub fn create(owner: *Build, exercise: Exercise, stderr: FileSource) *CheckNamedStep {
         const self = owner.allocator.create(CheckNamedStep) catch @panic("OOM");
         self.* = .{
             .step = Step.init(.{
@@ -213,7 +133,7 @@ const CheckNamedStep = struct {
                 .makeFn = make,
             }),
             .exercise = exercise,
-            .output = output,
+            .stderr = stderr,
         };
 
         return self;
@@ -222,34 +142,29 @@ const CheckNamedStep = struct {
     fn make(step: *Step, _: *std.Progress.Node) !void {
         const b = step.owner;
         const self = @fieldParentPtr(CheckNamedStep, "step", step);
+        const ex = self.exercise;
 
-        // Allow up to 1 MB of output capture.
-        const max_bytes = 1 * 1024 * 1024;
-        const path = self.output.getPath(b);
-        const raw_output = try fs.cwd().readFileAlloc(b.allocator, path, max_bytes);
+        const stderr_file = try fs.cwd().openFile(
+            self.stderr.getPath(b),
+            .{ .mode = .read_only },
+        );
+        defer stderr_file.close();
 
-        const actual = try root.trimLines(b.allocator, raw_output);
-        const expect = self.exercise.output;
-        if (!mem.eql(u8, expect, actual)) {
-            return step.fail("{s}: expected to see \"{s}\", found \"{s}\"", .{
-                self.exercise.main_file, expect, actual,
-            });
-        }
+        const stderr = stderr_file.reader();
+        try check_output(step, ex, stderr);
     }
 };
 
-/// Checks the output of `zig build` or `zig build -Dn=1 start`.
+/// Checks the output of `zig build`.
 const CheckStep = struct {
     step: Step,
     exercises: []const Exercise,
     stderr: FileSource,
-    has_logo: bool,
 
     pub fn create(
         owner: *Build,
         exercises: []const Exercise,
         stderr: FileSource,
-        has_logo: bool,
     ) *CheckStep {
         const self = owner.allocator.create(CheckStep) catch @panic("OOM");
         self.* = .{
@@ -261,7 +176,6 @@ const CheckStep = struct {
             }),
             .exercises = exercises,
             .stderr = stderr,
-            .has_logo = has_logo,
         };
 
         return self;
@@ -280,7 +194,7 @@ const CheckStep = struct {
 
         const stderr = stderr_file.reader();
         for (exercises) |ex| {
-            if (ex.number() == 1 and self.has_logo) {
+            if (ex.number() == 1) {
                 // Skip the logo.
                 const nlines = mem.count(u8, root.logo, "\n");
                 var buf: [80]u8 = undefined;
@@ -293,75 +207,75 @@ const CheckStep = struct {
             try check_output(step, ex, stderr);
         }
     }
-
-    fn check_output(step: *Step, exercise: Exercise, reader: Reader) !void {
-        const b = step.owner;
-
-        var buf: [1024]u8 = undefined;
-        if (exercise.skip) {
-            {
-                const actual = try readLine(reader, &buf) orelse "EOF";
-                const expect = b.fmt("Skipping {s}", .{exercise.main_file});
-                try check(step, exercise, expect, actual);
-            }
-
-            {
-                const actual = try readLine(reader, &buf) orelse "EOF";
-                try check(step, exercise, "", actual);
-            }
-
-            return;
-        }
-
-        {
-            const actual = try readLine(reader, &buf) orelse "EOF";
-            const expect = b.fmt("Compiling {s}...", .{exercise.main_file});
-            try check(step, exercise, expect, actual);
-        }
-
-        {
-            const actual = try readLine(reader, &buf) orelse "EOF";
-            const expect = b.fmt("Checking {s}...", .{exercise.main_file});
-            try check(step, exercise, expect, actual);
-        }
-
-        {
-            const actual = try readLine(reader, &buf) orelse "EOF";
-            const expect = "PASSED:";
-            try check(step, exercise, expect, actual);
-        }
-
-        // Skip the exercise output.
-        const nlines = 1 + mem.count(u8, exercise.output, "\n") + 1;
-        var lineno: usize = 0;
-        while (lineno < nlines) : (lineno += 1) {
-            _ = try readLine(reader, &buf) orelse @panic("EOF");
-        }
-    }
-
-    fn check(
-        step: *Step,
-        exercise: Exercise,
-        expect: []const u8,
-        actual: []const u8,
-    ) !void {
-        if (!mem.eql(u8, expect, actual)) {
-            return step.fail("{s}: expected to see \"{s}\", found \"{s}\"", .{
-                exercise.main_file,
-                expect,
-                actual,
-            });
-        }
-    }
-
-    fn readLine(reader: fs.File.Reader, buf: []u8) !?[]const u8 {
-        if (try reader.readUntilDelimiterOrEof(buf, '\n')) |line| {
-            return mem.trimRight(u8, line, " \r\n");
-        }
-
-        return null;
-    }
 };
+
+fn check_output(step: *Step, exercise: Exercise, reader: Reader) !void {
+    const b = step.owner;
+
+    var buf: [1024]u8 = undefined;
+    if (exercise.skip) {
+        {
+            const actual = try readLine(reader, &buf) orelse "EOF";
+            const expect = b.fmt("Skipping {s}", .{exercise.main_file});
+            try check(step, exercise, expect, actual);
+        }
+
+        {
+            const actual = try readLine(reader, &buf) orelse "EOF";
+            try check(step, exercise, "", actual);
+        }
+
+        return;
+    }
+
+    {
+        const actual = try readLine(reader, &buf) orelse "EOF";
+        const expect = b.fmt("Compiling {s}...", .{exercise.main_file});
+        try check(step, exercise, expect, actual);
+    }
+
+    {
+        const actual = try readLine(reader, &buf) orelse "EOF";
+        const expect = b.fmt("Checking {s}...", .{exercise.main_file});
+        try check(step, exercise, expect, actual);
+    }
+
+    {
+        const actual = try readLine(reader, &buf) orelse "EOF";
+        const expect = "PASSED:";
+        try check(step, exercise, expect, actual);
+    }
+
+    // Skip the exercise output.
+    const nlines = 1 + mem.count(u8, exercise.output, "\n") + 1;
+    var lineno: usize = 0;
+    while (lineno < nlines) : (lineno += 1) {
+        _ = try readLine(reader, &buf) orelse @panic("EOF");
+    }
+}
+
+fn check(
+    step: *Step,
+    exercise: Exercise,
+    expect: []const u8,
+    actual: []const u8,
+) !void {
+    if (!mem.eql(u8, expect, actual)) {
+        return step.fail("{s}: expected to see \"{s}\", found \"{s}\"", .{
+            exercise.main_file,
+            expect,
+            actual,
+        });
+    }
+}
+
+fn readLine(reader: fs.File.Reader, buf: []u8) !?[]const u8 {
+    if (try reader.readUntilDelimiterOrEof(buf, '\n')) |line| {
+        return mem.trimRight(u8, line, " \r\n");
+    }
+
+    return null;
+}
 
 /// Fails with a custom error message.
 const FailStep = struct {


### PR DESCRIPTION
This is a response to #296

  - [x] #297
  - [x] #298
  - [x] #299
  - [x] #214
  - [x] Improve the help message based on the context
    Suggest `zig build` or `zig build -Dn=n` based on the build mode.

## Current issues

  1. When, as example, the user run `zig build -Dn=86`, the output is a simple:
      ```
      Skipping 086_async3.zig
      ```
      that may confuse the user.
      Not sure is the solution is to simply document this in the `README.md` file or add a custom help message.
  2. I have not update the `README.md` file.

## Warning

@ratfactor, @chrboesch: This PR removes a lot of functionality.  Make sure to check if this simplification is worth.

Also note that I removed an additional comment added by @chrboesch in 879eeb6, since I also added a comment.
