### PR TITLE
Improve running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,5 @@ jobs:
         uses: goto-bus-stop/setup-zig@v2
         with:
           version: master
-# Temporarily disabled.
-#      - name: Run unit tests
-#        run: zig build test
+      - name: Run unit tests
+        run: zig build test


### PR DESCRIPTION
This fixes the unit tests and also improve the code in `ZiglingStep`, avoiding duplicate code when running `zig build-exe` or `zig test`.

Note that when a test succeeded, the output is a simple `PASS` in green color.

Now there are two check methods in `ZiglingStep`: `check_output` and `check_test`, while the `testing` method has been removed, using `compile` followed by `run` as with a normal exercise.