### PR TITLE
change std.debug.TTY to std.io.tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Verify the installation and build number of `zig` like so:
 
 ```
 $ zig version
-0.11.0-dev.2704+xxxxxxxxx
+0.11.0-dev.3295+xxxxxxxxx
 ```
 
 Clone this repository with Git:
@@ -89,7 +89,8 @@ that if you update one, you may need to also update the other.
 
 ### Version Changes
 
-Version-0.11.0-dev.2704+83970b6d9
+Version-0.11.0-dev.3295+7cb2e653a
+* *2023-05-25* zig 0.11.0-dev.3295 - `std.debug.TTY` is now `std.io.tty`
 * *2023-04-30* zig 0.11.0-dev.2704 - use of the new `std.Build.ExecutableOptions.link_libc` field
 * *2023-04-12* zig 0.11.0-dev.2560 - changes in `std.Build` - remove run() and install()
 * *2023-04-07* zig 0.11.0-dev.2401 - fixes of the new build system - see [#212](https://github.com/ratfactor/ziglings/pull/212)

--- a/build.zig
+++ b/build.zig
@@ -554,7 +554,7 @@ const ZiglingStep = struct {
 
         // Print the compiler errors.
         // TODO: use the same ttyconf from the builder.
-        const ttyconf: std.debug.TTY.Config = if (use_color_escapes)
+        const ttyconf: std.io.tty.Config = if (use_color_escapes)
             .escape_codes
         else
             .no_color;


### PR DESCRIPTION
The `std.debug.TTY` has been moved to `std.io.tty` in [commit](https://github.com/ziglang/zig/commit/0f6fa3f20b3b28958921bd63a9a9d96468455e9c)

So the latest dev build won't compile.