### PR TITLE
Fix wording of bit/byte in ex. 16

### DIFF
--- a/exercises/016_for2.zig
+++ b/exercises/016_for2.zig
@@ -17,7 +17,7 @@ const std = @import("std");
 
 pub fn main() void {
     // Let's store the bits of binary number 1101 in
-    // 'little-endian' order (least significant byte first):
+    // 'little-endian' bit order (least significant bit first):
     const bits = [_]u8{ 1, 0, 1, 1 };
     var value: u32 = 0;
 


### PR DESCRIPTION
Exercise 16 talks about storing the bits of a byte in a little-endian fashion, but then explains that little-endian means least significant _byte_ first. In this context, it should say least significant _bit_.