### PR TITLE
chore: update count of Zig built-in functions

### DIFF
--- a/exercises/064_builtins.zig
+++ b/exercises/064_builtins.zig
@@ -13,7 +13,7 @@
 // compiler, such as type introspection (the ability to examine
 // type properties from within a program).
 //
-// Zig currently contains 101 builtin functions. We're certainly
+// Zig currently contains 117 builtin functions. We're certainly
 // not going to cover them all, but we can look at some
 // interesting ones.
 //


### PR DESCRIPTION
It looks like Zig has 117 built-in functions now.

<img width="423" alt="image" src="https://github.com/ratfactor/ziglings/assets/3471836/b1ba4c71-ee34-4b51-ab03-fc4e9cb91703">
