### PR TITLE
Fix breaking change in builtin casts functions 

### DIFF
--- a/exercises/036_enums2.zig
+++ b/exercises/036_enums2.zig
@@ -57,8 +57,8 @@ pub fn main() void {
         \\</p>
         \\
     , .{
-        @enumToInt(Color.red),
-        @enumToInt(Color.green),
-        @enumToInt(???), // Oops! We're missing something!
+        @intFromEnum(Color.red),
+        @intFromEnum(Color.green),
+        @intFromEnum(???), // Oops! We're missing something!
     });
 }

--- a/exercises/096_memory_allocation.zig
+++ b/exercises/096_memory_allocation.zig
@@ -45,7 +45,7 @@ fn runningAverage(arr: []const f64, avg: []f64) void {
 
     for (0.., arr) |index, val| {
         sum += val;
-        avg[index] = sum / @intToFloat(f64, index + 1);
+        avg[index] = sum / @floatFromInt(f64, index + 1);
     }
 }
 

--- a/patches/patches/036_enums2.patch
+++ b/patches/patches/036_enums2.patch
@@ -7,6 +7,6 @@
 ---
 >         \\  <span style="color: #{x:0>6}">Blue</span>
 62c62
-<         @enumToInt(???), // Oops! We're missing something!
+<         @intFromEnum(???), // Oops! We're missing something!
 ---
->         @enumToInt(Color.blue), // Oops! We're missing something!
+>         @intFromEnum(Color.blue), // Oops! We're missing something!


### PR DESCRIPTION
While healing with `Eowyn` I noticed that two exercises are broken on latest build to date (`0.11.0-dev.3747`).

I looked up the doc and it seems that [builtin casts functions](https://ziglang.org/documentation/master/#Builtin-Functions) changed name in a very recent build.

So instead of the old `@enumToInt` and `@intToFloat` we need to use `@intFromEnum` and `@floatFromInt`

This affects [036_enums2.zig](https://github.com/ratfactor/ziglings/blob/1b1d6b020be4133fe8ba37ea209f89fbda5692de/exercises/036_enums2.zig) and [096_memory_allocation.zig](https://github.com/ratfactor/ziglings/blob/1b1d6b020be4133fe8ba37ea209f89fbda5692de/exercises/096_memory_allocation.zig)

Before breaking change:
```console
ubuntu@temp:~/ziglings$ zig version
0.11.0-dev.3395+7b5bd3a93
ubuntu@temp:~/ziglings$ zig build -Dhealed -Dn=36
         _       _ _
     ___(_) __ _| (_)_ __   __ _ ___
    |_  | |/ _' | | | '_ \ / _' / __|
     / /| | (_| | | | | | | (_| \__ \
    /___|_|\__, |_|_|_| |_|\__, |___/
           |___/           |___/

    "Look out! Broken programs below!"

Compiling 036_enums2.zig...
Checking 036_enums2.zig...
PASSED:
<p>
  <span style="color: #ff0000">Red</span>
  <span style="color: #00ff00">Green</span>
  <span style="color: #0000ff">Blue</span>
</p>
```

Before fix:
```console
ubuntu@temp:~/ziglings$ zig version
0.11.0-dev.3747+7b5bd3a93
ubuntu@temp:~/ziglings$ zig build -Dhealed -Dn=36
         _       _ _
     ___(_) __ _| (_)_ __   __ _ ___
    |_  | |/ _' | | | '_ \ / _' / __|
     / /| | (_| | | | | | | (_| \__ \
    /___|_|\__, |_|_|_| |_|\__, |___/
           |___/           |___/

    "Look out! Broken programs below!"

Compiling 036_enums2.zig...
error: the following command failed with 1 compilation errors:
/usr/bin/zig/zig build-exe /home/ubuntu/ziglings/exercises/036_enums2.zig --cache-dir /home/ubuntu/ziglings/zig-cache --listen=- 
exercises/036_enums2.zig:60:9: error: invalid builtin function: '@enumToInt'
        @enumToInt(Color.red),
        ^~~~~~~~~~~~~~~~~~~~~

Ziglings hint: I'm feeling blue about this.
Edit exercises/036_enums2.zig and run 'zig build -Dn=36' again.
```

After fix:
```console
ubuntu@temp:~/ziglings$ zig version
0.11.0-dev.3747+7b5bd3a93
ubuntu@temp:~/ziglings$ zig build -Dhealed -Dn=36
         _       _ _
     ___(_) __ _| (_)_ __   __ _ ___
    |_  | |/ _' | | | '_ \ / _' / __|
     / /| | (_| | | | | | | (_| \__ \
    /___|_|\__, |_|_|_| |_|\__, |___/
           |___/           |___/

    "Look out! Broken programs below!"

Compiling 036_enums2.zig...
Checking 036_enums2.zig...
PASSED:
<p>
  <span style="color: #ff0000">Red</span>
  <span style="color: #00ff00">Green</span>
  <span style="color: #0000ff">Blue</span>
</p>
```

I hope I did everything right, I'm new to the repo and zig, so feel free to point out anything wrong