### PR TITLE
Change `var` to `const` in some exercises

### DIFF
--- a/exercises/010_if2.zig
+++ b/exercises/010_if2.zig
@@ -1,16 +1,16 @@
 //
 // If statements are also valid expressions:
 //
-//     var foo: u8 = if (a) 2 else 3;
+//     const foo: u8 = if (a) 2 else 3;
 //
 const std = @import("std");
 
 pub fn main() void {
-    var discount = true;
+    const discount = true;
 
     // Please use an if...else expression to set "price".
     // If discount is true, the price should be $17, otherwise $20:
-    var price: u8 = if ???;
+    const price: u8 = if ???;
 
     std.debug.print("With the discount, the price is ${}.\n", .{price});
 }

--- a/exercises/016_for2.zig
+++ b/exercises/016_for2.zig
@@ -29,7 +29,7 @@ pub fn main() void {
         // Note that we convert the usize i to a u32 with
         // @intCast(), a builtin function just like @import().
         // We'll learn about these properly in a later exercise.
-        var place_value = std.math.pow(u32, 2, @intCast(u32, i));
+        const place_value = std.math.pow(u32, 2, @intCast(u32, i));
         value += place_value * bit;
     }
 

--- a/exercises/017_quiz2.zig
+++ b/exercises/017_quiz2.zig
@@ -13,7 +13,7 @@ const std = import standard library;
 
 function main() void {
     var i: u8 = 1;
-    var stop_at: u8 = 16;
+    const stop_at: u8 = 16;
 
     // What kind of loop is this? A 'for' or a 'while'?
     ??? (i <= stop_at) : (i += 1) {

--- a/exercises/023_errors3.zig
+++ b/exercises/023_errors3.zig
@@ -11,8 +11,8 @@ const std = @import("std");
 const MyNumberError = error{TooSmall};
 
 pub fn main() void {
-    var a: u32 = addTwenty(44) catch 22;
-    var b: u32 = addTwenty(4) ??? 22;
+    const a: u32 = addTwenty(44) catch 22;
+    const b: u32 = addTwenty(4) ??? 22;
 
     std.debug.print("a={}, b={}\n", .{ a, b });
 }

--- a/exercises/024_errors4.zig
+++ b/exercises/024_errors4.zig
@@ -21,9 +21,9 @@ const MyNumberError = error{
 pub fn main() void {
     // The "catch 0" below is a temporary hack to deal with
     // makeJustRight()'s returned error union (for now).
-    var a: u32 = makeJustRight(44) catch 0;
-    var b: u32 = makeJustRight(14) catch 0;
-    var c: u32 = makeJustRight(4) catch 0;
+    const a: u32 = makeJustRight(44) catch 0;
+    const b: u32 = makeJustRight(14) catch 0;
+    const c: u32 = makeJustRight(4) catch 0;
 
     std.debug.print("a={}, b={}, c={}\n", .{ a, b, c });
 }

--- a/exercises/025_errors5.zig
+++ b/exercises/025_errors5.zig
@@ -15,9 +15,9 @@ const MyNumberError = error{
 };
 
 pub fn main() void {
-    var a: u32 = addFive(44) catch 0;
-    var b: u32 = addFive(14) catch 0;
-    var c: u32 = addFive(4) catch 0;
+    const a: u32 = addFive(44) catch 0;
+    const b: u32 = addFive(14) catch 0;
+    const c: u32 = addFive(4) catch 0;
 
     std.debug.print("a={}, b={}, c={}\n", .{ a, b, c });
 }

--- a/exercises/031_switch2.zig
+++ b/exercises/031_switch2.zig
@@ -2,7 +2,7 @@
 // What's really nice is that you can use a switch statement as an
 // expression to return a value.
 //
-//     var a = switch (x) {
+//     const a = switch (x) {
 //         1 => 9,
 //         2 => 16,
 //         3 => 7,

--- a/exercises/036_enums2.zig
+++ b/exercises/036_enums2.zig
@@ -9,7 +9,7 @@
 // @enumToInt(). We'll learn about builtins properly in a later
 // exercise.
 //
-//     var my_stuff: u8 = @enumToInt(Stuff.foo);
+//     const my_stuff: u8 = @enumToInt(Stuff.foo);
 //
 // Note how that built-in function starts with "@" just like the
 // @import() function we've been using.

--- a/exercises/036_enums2.zig
+++ b/exercises/036_enums2.zig
@@ -6,10 +6,10 @@
 //     const Stuff = enum(u8){ foo = 16 };
 //
 // You can get the integer out with a builtin function,
-// @enumToInt(). We'll learn about builtins properly in a later
+// @intFromEnum(). We'll learn about builtins properly in a later
 // exercise.
 //
-//     const my_stuff: u8 = @enumToInt(Stuff.foo);
+//     const my_stuff: u8 = @intFromEnum(Stuff.foo);
 //
 // Note how that built-in function starts with "@" just like the
 // @import() function we've been using.

--- a/exercises/045_optionals.zig
+++ b/exercises/045_optionals.zig
@@ -29,7 +29,7 @@ pub fn main() void {
 
     // Please threaten the result so that answer is either the
     // integer value from deepThought() OR the number 42:
-    var answer: u8 = result;
+    const answer: u8 = result;
 
     std.debug.print("The Ultimate Answer: {}.\n", .{answer});
 }

--- a/exercises/047_methods.zig
+++ b/exercises/047_methods.zig
@@ -78,7 +78,7 @@ pub fn main() void {
     };
 
     var aliens_alive = aliens.len;
-    var heat_ray = HeatRay{ .damage = 7 }; // We've been given a heat ray weapon.
+    const heat_ray = HeatRay{ .damage = 7 }; // We've been given a heat ray weapon.
 
     // We'll keep checking to see if we've killed all the aliens yet.
     while (aliens_alive > 0) {

--- a/exercises/059_integers.zig
+++ b/exercises/059_integers.zig
@@ -18,7 +18,7 @@
 const print = @import("std").debug.print;
 
 pub fn main() void {
-    var zig = [_]u8{
+    const zig = [_]u8{
         0o131, // octal
         0b1101000, // binary
         0x66, // hex

--- a/exercises/060_floats.zig
+++ b/exercises/060_floats.zig
@@ -43,7 +43,7 @@ pub fn main() void {
     //
     // We'll convert this weight from tons to kilograms at a
     // conversion of 907.18kg to the ton.
-    var shuttle_weight: f16 = 907.18 * 2200;
+    const shuttle_weight: f16 = 907.18 * 2200;
 
     // By default, float values are formatted in scientific
     // notation. Try experimenting with '{d}' and '{d:.3}' to see

--- a/exercises/064_builtins.zig
+++ b/exercises/064_builtins.zig
@@ -4,7 +4,7 @@
 // Ziglings exercise.
 //
 // We've also seen @intCast() in "016_for2.zig", "058_quiz7.zig";
-// and @enumToInt() in "036_enums2.zig".
+// and @intFromEnum() in "036_enums2.zig".
 //
 // Builtins are special because they are intrinsic to the Zig
 // language itself (as opposed to being provided in the standard

--- a/exercises/065_builtins2.zig
+++ b/exercises/065_builtins2.zig
@@ -1,13 +1,13 @@
 //
 // Zig has builtins for mathematical operations such as...
 //
-//      @sqrt        @sin          @cos
-//      @exp         @log          @floor
+//      @sqrt        @sin           @cos
+//      @exp         @log           @floor
 //
 // ...and lots of type casting operations such as...
 //
-//      @as          @intToError   @intToFloat
-//      @intToPtr    @ptrToInt     @enumToInt
+//      @as          @errorFromInt  @floatFromInt
+//      @ptrFromInt  @intFromPtr    @intFromEnum
 //
 // Spending part of a rainy day skimming through the complete
 // list of builtins in the official Zig documentation wouldn't be

--- a/patches/patches/010_if2.patch
+++ b/patches/patches/010_if2.patch
@@ -1,4 +1,4 @@
 13c13
-<     var price: u8 = if ???;
+<     const price: u8 = if ???;
 ---
->     var price: u8 = if (discount) 17 else 20;
+>     const price: u8 = if (discount) 17 else 20;

--- a/patches/patches/023_errors3.patch
+++ b/patches/patches/023_errors3.patch
@@ -1,7 +1,7 @@
 15c15
-<     var b: u32 = addTwenty(4) ??? 22;
+<     const b: u32 = addTwenty(4) ??? 22;
 ---
->     var b: u32 = addTwenty(4) catch 22;
+>     const b: u32 = addTwenty(4) catch 22;
 22c22
 < fn addTwenty(n: u32) ??? {
 ---

--- a/patches/patches/045_optionals.patch
+++ b/patches/patches/045_optionals.patch
@@ -1,4 +1,4 @@
 32c32
-<     var answer: u8 = result;
+<     const answer: u8 = result;
 ---
->     var answer: u8 = result orelse 42;
+>     const answer: u8 = result orelse 42;

--- a/patches/patches/060_floats.patch
+++ b/patches/patches/060_floats.patch
@@ -1,4 +1,4 @@
 43c43
-<     var shuttle_weight: f16 = 907.18 * 2200;
+<     const shuttle_weight: f16 = 907.18 * 2200;
 ---
->     var shuttle_weight: f32 = 907.18 * 2200.0;
+>     const shuttle_weight: f32 = 907.18 * 2200.0;


### PR DESCRIPTION
As explained in #324 , I changed some variable declaration to constants. I also tried to update the comments when it made sense.
Some variable *could* be changed to constant like `num1` here in `039_pointers.zig` but it would require to also change `num1_pointer` to be `*const u8`.
https://github.com/ratfactor/ziglings/blob/08e8a0f1e48954c4b4657c0078bb5b3ef0c8d13d/exercises/039_pointers.zig#L25-L36

Since this exercise is trying to explain how pointers works I assumed it would not be a good idea to make the change. The same applies to exercise `066_comptime.zig` and after, where we already make use of const and comptime.

I also understand that changing variables to constants may give away the answer to some exercise. Feel free to not merge some changes to some exercises if you think it's not worth it.


Everything was built and run with `zig 0.11.0-dev.3747`

NB: I also updated outdated comments referencing the change in builtin casts as I forgot to check those in my previous PR. (see: #327)