### PR TITLE
Revised exercises due to the changes of Zig version 0.11.0-dev.3853

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Verify the installation and build number of `zig` like so:
 
 ```
 $ zig version
-0.11.0-dev.3747+xxxxxxxxx
+0.11.0-dev.3853+xxxxxxxxx
 ```
 
 Clone this repository with Git:
@@ -90,7 +90,8 @@ that if you update one, you may need to also update the other.
 ### Version Changes
 
 Version-0.11.0-dev.3747+7b5bd3a93
-* *2023-05-25* zig 0.11.0-dev.3747 - `@enumToInt` is now `@intFromEnum` and `@intToFloat` is now `@floatFromInt`
+* *2023-06-26* zig 0.11.0-dev.3853 - removal of destination type from all cast builtins
+* *2023-06-20* zig 0.11.0-dev.3747 - `@enumToInt` is now `@intFromEnum` and `@intToFloat` is now `@floatFromInt`
 * *2023-05-25* zig 0.11.0-dev.3295 - `std.debug.TTY` is now `std.io.tty`
 * *2023-04-30* zig 0.11.0-dev.2704 - use of the new `std.Build.ExecutableOptions.link_libc` field
 * *2023-04-12* zig 0.11.0-dev.2560 - changes in `std.Build` - remove run() and install()
@@ -211,7 +212,7 @@ Zig Standard Library
 
 * [X] String formatting
 * [X] Testing
-* [ ] Tokenization
+* [X] Tokenization
 
 ## Contributing
 

--- a/build.zig
+++ b/build.zig
@@ -104,7 +104,7 @@ pub fn build(b: *Build) !void {
             const WINAPI = std.os.windows.WINAPI;
             const DWORD = std.os.windows.DWORD;
             const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
-            const STD_ERROR_HANDLE = @bitCast(DWORD, @as(i32, -12));
+            const STD_ERROR_HANDLE: DWORD = @bitCast(@as(i32, -12));
             extern "kernel32" fn GetStdHandle(id: DWORD) callconv(WINAPI) ?*anyopaque;
             extern "kernel32" fn GetConsoleMode(console: ?*anyopaque, out_mode: *DWORD) callconv(WINAPI) u32;
             extern "kernel32" fn SetConsoleMode(console: ?*anyopaque, mode: DWORD) callconv(WINAPI) u32;

--- a/exercises/016_for2.zig
+++ b/exercises/016_for2.zig
@@ -29,7 +29,8 @@ pub fn main() void {
         // Note that we convert the usize i to a u32 with
         // @intCast(), a builtin function just like @import().
         // We'll learn about these properly in a later exercise.
-        const place_value = std.math.pow(u32, 2, @intCast(u32, i));
+        const i_u32: u32 = @intCast(i);
+        const place_value = std.math.pow(u32, 2, i_u32);
         value += place_value * bit;
     }
 

--- a/exercises/058_quiz7.zig
+++ b/exercises/058_quiz7.zig
@@ -429,7 +429,7 @@ fn printTrip(trip: []?TripItem) void {
     // We convert the usize length to a u8 with @intCast(), a
     // builtin function just like @import().  We'll learn about
     // these properly in a later exercise.
-    var i: u8 = @intCast(u8, trip.len);
+    var i: u8 = @intCast(trip.len);
 
     while (i > 0) {
         i -= 1;

--- a/exercises/069_comptime4.zig
+++ b/exercises/069_comptime4.zig
@@ -47,7 +47,7 @@ fn makeSequence(comptime T: type, ??? size: usize) [???]T {
     var i: usize = 0;
 
     while (i < size) : (i += 1) {
-        sequence[i] = @intCast(T, i) + 1;
+        sequence[i] = @as(T, @intCast(i)) + 1;
     }
 
     return sequence;

--- a/exercises/075_quiz8.zig
+++ b/exercises/075_quiz8.zig
@@ -204,7 +204,7 @@ pub fn main() void {
 }
 
 fn printTrip(trip: []?TripItem) void {
-    var i: u8 = @intCast(u8, trip.len);
+    var i: u8 = @intCast(trip.len);
 
     while (i > 0) {
         i -= 1;

--- a/exercises/096_memory_allocation.zig
+++ b/exercises/096_memory_allocation.zig
@@ -45,7 +45,8 @@ fn runningAverage(arr: []const f64, avg: []f64) void {
 
     for (0.., arr) |index, val| {
         sum += val;
-        avg[index] = sum / @floatFromInt(f64, index + 1);
+        const f_index: f64 = @floatFromInt(index + 1);
+        avg[index] = sum / f_index;
     }
 }
 

--- a/exercises/098_bit_manipulation2.zig
+++ b/exercises/098_bit_manipulation2.zig
@@ -53,7 +53,7 @@ fn isPangram(str: []const u8) bool {
             // and are numbered sequentially, we simply subtract the
             // first letter (in this case the 'a') from the character
             // found, and thus get the position of the desired bit
-            bits |= @as(u32, 1) << @truncate(u5, ascii.toLower(c) - 'a');
+            bits |= @as(u32, 1) << @truncate(ascii.toLower(c) - 'a');
         }
     }
     // last we return the comparison if all 26 bits are set,

--- a/patches/patches/078_sentinels3.patch
+++ b/patches/patches/078_sentinels3.patch
@@ -1,4 +1,4 @@
 24c24
 <     const printable: [*:0]const u8 = ???;
 ---
->     const printable: [*:0]const u8 = @ptrCast([*:0]const u8, data);
+>     const printable: [*:0]const u8 = @ptrCast(data);

--- a/patches/patches/096_memory_allocation.patch
+++ b/patches/patches/096_memory_allocation.patch
@@ -1,4 +1,4 @@
-66c66
+67c67
 <     var avg: []f64 = ???;
 ---
 >     var avg: []f64 = try allocator.alloc(f64, arr.len);

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -15,7 +15,7 @@ const print = if (@hasDecl(debug, "print")) debug.print else debug.warn;
 // When changing this version, be sure to also update README.md in two places:
 //     1) Getting Started
 //     2) Version Changes
-const needed_version_str = "0.11.0-dev.3747";
+const needed_version_str = "0.11.0-dev.3853";
 
 fn isCompatible() bool {
     if (!@hasDecl(builtin, "zig_version") or !@hasDecl(std, "SemanticVersion")) {


### PR DESCRIPTION
Closes https://github.com/ratfactor/ziglings/issues/332

See also: [removal of destination type from all cast builtins](https://ziggit.dev/t/major-zig-language-update-just-landed-removal-of-destination-type-from-all-cast-builtins/898)