### PR TITLE
fix: main entry point is broken with version 0.11.0-dev.4228

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -240,7 +240,7 @@ const ZiglingStep = struct {
             std.os.exit(2);
         };
 
-        self.run(exe_path, prog_node) catch {
+        self.run(exe_path.?, prog_node) catch {
             self.printErrors();
 
             if (self.exercise.hint) |hint|
@@ -350,7 +350,7 @@ const ZiglingStep = struct {
         print("{s}PASSED{s}\n\n", .{ green_text, reset_text });
     }
 
-    fn compile(self: *ZiglingStep, prog_node: *std.Progress.Node) ![]const u8 {
+    fn compile(self: *ZiglingStep, prog_node: *std.Progress.Node) !?[]const u8 {
         print("Compiling {s}...\n", .{self.exercise.main_file});
 
         const b = self.step.owner;


### PR DESCRIPTION
Hi!
The compilation of `build.zig` is broken with the newest compiler version (`0.11.0-dev.4228`).
Note that I'm fairly new to zig (haven't even done the ziglings yet), and only followed the compiler recommendation, so I'm note sure how to handle the option unwrapping properly (`.?`).