### PR TITLE
fix: local varianble is never mutated

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -263,7 +263,7 @@ const ZiglingStep = struct {
         // Allow up to 1 MB of stdout capture.
         const max_output_bytes = 1 * 1024 * 1024;
 
-        var result = Child.exec(.{
+        const result = Child.exec(.{
             .allocator = b.allocator,
             .argv = &.{exe_path},
             .cwd = b.build_root.path.?,

--- a/exercises/025_errors5.zig
+++ b/exercises/025_errors5.zig
@@ -26,7 +26,7 @@ fn addFive(n: u32) MyNumberError!u32 {
     // This function needs to return any error which might come back from detect().
     // Please use a "try" statement rather than a "catch".
     //
-    var x = detect(n);
+    const x = detect(n);
 
     return x + 5;
 }

--- a/exercises/029_errdefer.zig
+++ b/exercises/029_errdefer.zig
@@ -21,8 +21,8 @@ const MyErr = error{ GetFail, IncFail };
 
 pub fn main() void {
     // We simply quit the entire program if we fail to get a number:
-    var a: u32 = makeNumber() catch return;
-    var b: u32 = makeNumber() catch return;
+    const a: u32 = makeNumber() catch return;
+    const b: u32 = makeNumber() catch return;
 
     std.debug.print("Numbers: {}, {}\n", .{ a, b });
 }

--- a/exercises/039_pointers.zig
+++ b/exercises/039_pointers.zig
@@ -24,7 +24,7 @@ const std = @import("std");
 
 pub fn main() void {
     var num1: u8 = 5;
-    var num1_pointer: *u8 = &num1;
+    const num1_pointer: *u8 = &num1;
 
     var num2: u8 = undefined;
 

--- a/exercises/048_methods2.zig
+++ b/exercises/048_methods2.zig
@@ -24,7 +24,7 @@ const Elephant = struct {
 
     pub fn print(self: *Elephant) void {
         // Prints elephant letter and [v]isited
-        var v: u8 = if (self.visited) 'v' else ' ';
+        const v: u8 = if (self.visited) 'v' else ' ';
         std.debug.print("{u}{u} ", .{ self.letter, v });
     }
 };

--- a/exercises/049_quiz6.zig
+++ b/exercises/049_quiz6.zig
@@ -37,7 +37,7 @@ const Elephant = struct {
 
     pub fn print(self: *Elephant) void {
         // Prints elephant letter and [v]isited
-        var v: u8 = if (self.visited) 'v' else ' ';
+        const v: u8 = if (self.visited) 'v' else ' ';
         std.debug.print("{u}{u} ", .{ self.letter, v });
     }
 };

--- a/exercises/055_unions.zig
+++ b/exercises/055_unions.zig
@@ -53,8 +53,8 @@ const AntOrBee = enum { a, b };
 
 pub fn main() void {
     // We'll just make one bee and one ant to test them out:
-    var ant = Insect{ .still_alive = true };
-    var bee = Insect{ .flowers_visited = 15 };
+    const ant = Insect{ .still_alive = true };
+    const bee = Insect{ .flowers_visited = 15 };
 
     std.debug.print("Insect report! ", .{});
 

--- a/exercises/056_unions2.zig
+++ b/exercises/056_unions2.zig
@@ -38,8 +38,8 @@ const Insect = union(InsectStat) {
 };
 
 pub fn main() void {
-    var ant = Insect{ .still_alive = true };
-    var bee = Insect{ .flowers_visited = 16 };
+    const ant = Insect{ .still_alive = true };
+    const bee = Insect{ .flowers_visited = 16 };
 
     std.debug.print("Insect report! ", .{});
 

--- a/exercises/057_unions3.zig
+++ b/exercises/057_unions3.zig
@@ -21,8 +21,8 @@ const Insect = union(InsectStat) {
 };
 
 pub fn main() void {
-    var ant = Insect{ .still_alive = true };
-    var bee = Insect{ .flowers_visited = 17 };
+    const ant = Insect{ .still_alive = true };
+    const bee = Insect{ .flowers_visited = 17 };
 
     std.debug.print("Insect report! ", .{});
 


### PR DESCRIPTION
In zig version 0.12.0_dev.700+376242e58-1 it is impossible to have a var which is never mutated. This breaks not only some ziglings but the build itself. Keep in mind I currently on the 57th zigling and there should be more mistake like these. 

None of the fixes fix the actual task given during the ziglings. They only fix the:

`error: local variable never mutated`